### PR TITLE
Add a cache for metric metadata.

### DIFF
--- a/biggraphite/accessor.py
+++ b/biggraphite/accessor.py
@@ -185,13 +185,24 @@ class MetricMetadata(object):
             self.carbon_xfilesfactor = self._DEFAULT_XFILESFACTOR
         self.carbon_highest_precision = self.carbon_retentions[0][0]
 
+    def as_json(self):
+        """Serialize MetricMetadata into a JSon string from_json() can parse."""
+        return json.dumps(self.as_string_dict())
+
     def as_string_dict(self):
         """Turn an instance into a dict of string to string."""
         return {
+            "name": self.name,
             "carbon_aggregation": self.carbon_aggregation,
             "carbon_retentions": json.dumps(self.carbon_retentions),
             "carbon_xfilesfactor": "%f" % self.carbon_xfilesfactor,
         }
+
+    @classmethod
+    def from_json(cls, s):
+        """Parse MetricMetadata from a JSon string produced by as_json()."""
+        d = json.loads(s)
+        return cls.from_string_dict(d)
 
     @classmethod
     def from_string_dict(cls, d):
@@ -443,9 +454,12 @@ class Accessor(object):
             ))
         padding = [None] * (_COMPONENTS_MAX_LEN - len(components))
         # Finally, create the metric
+        metric_metadata_dict = metric_metadata.as_string_dict()
+        # We drop the name from the json as name is already the first column.
+        del metric_metadata_dict["name"]
         queries.append((
             self.__insert_metrics_statement,
-            [metric_name, metric_metadata.as_string_dict()] + components + padding,
+            [metric_name, metric_metadata_dict] + components + padding,
         ))
 
         # We have to run queries in sequence as:

--- a/biggraphite/metadata_cache.py
+++ b/biggraphite/metadata_cache.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+# Copyright 2016 Criteo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Implements the DiskCache for metrics metadata.
+
+The DiskCache is implemented with lmdb, an on-disk file DB that can be accessed
+by multiple processes. Keys are metric names, values are json-serialised metadata.
+In deployment the graphite storage dir is used as a rendez-vous point where all processes
+(carbon, graphite, ...) can find the metadata.
+
+TODO(b.arnould): Currently that cache never expires, as we don't allow for deletion.
+"""
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+from os import path as os_path
+import threading
+
+import lmdb
+
+from biggraphite import accessor as bg_accessor
+
+
+class Error(Exception):
+    """Base class for all exceptions from this module."""
+
+
+class InvalidArgumentError(Error):
+    """Callee did not follow requirements on the arguments."""
+
+
+class DiskCache(object):
+    """A metadata cache that can be shared between processes trusting each other.
+
+    open() and close() are the only thread unsafe methods.
+    See module-level comments for the design.
+    """
+
+    __SINGLETONS = {}
+    __SINGLETONS_LOCK = threading.Lock()
+    # Maximum number of concurrent readers.
+    # Used to size a file that is mmapped in all readers. Cannot be raised while the DB is opened.
+    # According to LMDB's author, 128 readers is about 8KiB of RAM, 1024 is about 128kiB and even
+    # 4096 is safe: https://twitter.com/armon/status/534867803426533376
+    _MAX_READERS = 2048
+
+    def __init__(self, accessor, path):
+        """Create a new DiskCache."""
+        self.hit_count = 0
+        self.miss_count = 0
+        self.__accessor_lock = threading.Lock()
+        self.__accessor = accessor
+        self.__env = None
+        # __json_cache associates unparsed json to metadata instances. The idea is that there are
+        # very few configs in use in a given cluster so the few same strings will show up over
+        # and over.
+        self.__json_cache_lock = threading.Lock()
+        self.__json_cache = {}
+        self.__metric_to_metadata_db = None
+        self.__path = os_path.join(path, "biggraphite", "cache", "version0")
+
+    def open(self):
+        """Allocate ressources used by the cache.
+
+        Safe to call again after close() returned.
+        """
+        if self.__env:
+            return
+        try:
+            os.makedirs(self.__path)
+        except OSError:
+            pass  # Directory already exists
+        self.__env = lmdb.open(
+            self.__path,
+            # Only one sync per transaction, system crash can undo a transaction.
+            metasync=False,
+            # Use mmap()
+            writemap=True,
+            # Max number of concurrent readers, see _MAX_READERS for details
+            max_readers=self._MAX_READERS,
+            # How many DBs we may create (until we increase version prefix).
+            max_dbs=8,
+            # A cache of read-only transactions, should match max number of threads.
+            # Only transactions that are actually used concurrently allocate memory,
+            # so setting a high number doesn't cost much even if thread count is low.
+            max_spare_txns=128,
+        )
+        self.__metric_to_metadata_db = self.__env.open_db("metric_to_meta")
+
+    def close(self):
+        """Free resources allocated by open().
+
+        Safe to call multiple time.
+        """
+        if self.__env:
+            self.__env.close()
+            self.__env = None
+
+    def create_metric(self, metadata):
+        """Create a metric definition from a MetricMetadata.
+
+        Args:
+          metadata: The metric definition.
+        """
+        self.__accessor.create_metric(metadata)
+        self._cache(metadata)
+
+    def get_metric(self, metric_name):
+        """Return a MetricMetadata for this metric_name, None if no such metric."""
+        with self.__env.begin(self.__metric_to_metadata_db, write=False) as txn:
+            metadata_str = txn.get(metric_name)
+        if metadata_str:
+            # on disk cache hit
+            self.hit_count += 1
+            with self.__json_cache_lock:
+                metadata = self.__json_cache.get(metadata_str)
+                if not metadata:
+                    metadata = bg_accessor.MetricMetadata.from_json(metadata_str)
+                    self.__json_cache[metadata_str] = metadata
+            return metadata
+        else:
+            # on disk cache miss
+            self.miss_count += 1
+            with self.__accessor_lock:
+                metadata = self.__accessor.get_metric(metric_name)
+            self._cache(metadata)
+            return metadata
+
+    def _cache(self, metadata):
+        """If metadata add it to the cache."""
+        if not metadata:
+            # Do not cache absent metrics, they will probably soon be created.
+            return None
+        metadata_json = metadata.as_json()
+        with self.__env.begin(self.__metric_to_metadata_db, write=True) as txn:
+            txn.put(metadata.name, metadata_json, dupdata=False, overwrite=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 cassandra-driver
+lmdb
 progressbar2
 sortedcontainers
 statistics

--- a/tests/test_carbon.py
+++ b/tests/test_carbon.py
@@ -36,6 +36,7 @@ class TestCarbonDatabase(bg_test_utils.TestCaseWithFakeAccessor):
         settings = carbon_conf.Settings()
         settings["BG_CONTACT_POINTS"] = "host1,host2"
         settings["BG_KEYSPACE"] = self.KEYSPACE
+        settings["STORAGE_DIR"] = self.tempdir
         self._plugin = bg_carbon.BigGraphiteDatabase(settings)
         self._plugin.create(
             _TEST_METRIC,

--- a/tests/test_graphite.py
+++ b/tests/test_graphite.py
@@ -68,7 +68,7 @@ class TestReader(bg_test_utils.TestCaseWithFakeAccessor):
         )
         self.accessor.create_metric(meta)
         self.accessor.insert_points(_METRIC_NAME, self._POINTS)
-        self.reader = bg_graphite.Reader(self.accessor, _METRIC_NAME)
+        self.reader = bg_graphite.Reader(self.accessor, self.metadata_cache, _METRIC_NAME)
 
     def test_fresh_read(self):
         (start, end, step), points = self.reader.fetch(
@@ -112,7 +112,10 @@ class TestFinder(bg_test_utils.TestCaseWithFakeAccessor):
         for metric in "a", "a.a", "a.b.c", "x.y":
             meta = bg_accessor.MetricMetadata(metric)
             self.accessor.create_metric(meta)
-        self.finder = bg_graphite.Finder(accessor=self.accessor)
+        self.finder = bg_graphite.Finder(
+            accessor=self.accessor,
+            metadata_cache=self.metadata_cache,
+        )
 
     def find_nodes(self, pattern):
         return self.finder.find_nodes(FakeFindQuery(pattern))

--- a/tests/test_metadata_cache.py
+++ b/tests/test_metadata_cache.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# Copyright 2016 Criteo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import print_function
+
+import unittest
+
+from biggraphite import accessor as bg_accessor
+from biggraphite import test_utils as bg_test_utils
+
+_TEST_METRIC = bg_accessor.MetricMetadata("a.b.c")
+
+
+class TestGraphiteUtilsInternals(bg_test_utils.TestCaseWithFakeAccessor):
+
+    def _assert_hit_miss(self, hit, miss):
+        self.assertEqual(hit, self.metadata_cache.hit_count)
+        self.assertEqual(miss, self.metadata_cache.miss_count)
+
+    def test_double_open(self):
+        self.metadata_cache.open()
+        self.metadata_cache.close()
+
+    def test_hit_counts(self):
+        """Check that we use the on disk cache to reduce access reads."""
+        hit, miss = 0, 0
+        self._assert_hit_miss(hit, miss)
+
+        self.metadata_cache.get_metric(_TEST_METRIC.name)
+        miss += 1
+        self._assert_hit_miss(hit, miss)
+
+        self.metadata_cache.create_metric(_TEST_METRIC)
+        self._assert_hit_miss(hit, miss)
+
+        self.metadata_cache.get_metric(_TEST_METRIC.name)
+        hit += 1
+        self._assert_hit_miss(hit, miss)
+
+    def test_instance_cache(self):
+        """Check that we do cache JSON instances."""
+        self.metadata_cache.create_metric(_TEST_METRIC)
+        first = self.metadata_cache.get_metric(_TEST_METRIC.name)
+        second = self.metadata_cache.get_metric(_TEST_METRIC.name)
+        self.assertIs(first, second)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The DiskCache is implemented with lmdb, an on-disk file DB that can be accessed by multiple processes. Keys are metric names, values are json-serialised metadata.
In deployment the graphite storage dir is used as a rendez-vous point where all processes (carbon, graphite, ...) can find the metadata.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/biggraphite/20)
<!-- Reviewable:end -->
