### PR TITLE
Faster tests.

### DIFF
--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -83,7 +83,19 @@ class TestMetricMetadata(unittest.TestCase):
         self.assertEqual(0.5, m_default.carbon_xfilesfactor)
 
 
-class TestWithCassandra(bg_test_utils.TestCaseWithAccessor):
+class TestAccessorWithCassandra(bg_test_utils.TestCaseWithAccessor):
+
+    def setUp(self):
+        """Create a new Accessor in self.acessor."""
+        super(TestAccessorWithCassandra, self).setUp()
+        self.accessor.connect()
+
+    def test_context_manager(self):
+        self.accessor.shutdown()
+        self.assertFalse(self.accessor.is_connected)
+        with self.accessor:
+            self.assertTrue(self.accessor.is_connected)
+        self.assertFalse(self.accessor.is_connected)
 
     def test_fetch_empty(self):
         self.accessor.insert_points(_METRIC, _POINTS)

--- a/tests/test_carbon.py
+++ b/tests/test_carbon.py
@@ -18,6 +18,7 @@ from biggraphite import test_utils as bg_test_utils   # noqa
 bg_test_utils.prepare_graphite_imports()  # noqa
 
 import unittest
+
 from carbon import conf as carbon_conf
 from carbon import exceptions as carbon_exceptions
 
@@ -27,13 +28,14 @@ from biggraphite.plugins import carbon as bg_carbon
 _TEST_METRIC = "mytestmetric"
 
 
-class TestCarbonDatabase(bg_test_utils.TestCaseWithAccessor):
+class TestCarbonDatabase(bg_test_utils.TestCaseWithFakeAccessor):
 
     def setUp(self):
+        super(TestCarbonDatabase, self).setUp()
+        self.patch_accessor()
         settings = carbon_conf.Settings()
-        settings["BG_CONTACT_POINTS"] = ",".join(self.contact_points)
+        settings["BG_CONTACT_POINTS"] = "host1,host2"
         settings["BG_KEYSPACE"] = self.KEYSPACE
-        settings["BG_PORT"] = self.port
         self._plugin = bg_carbon.BigGraphiteDatabase(settings)
         self._plugin.create(
             _TEST_METRIC,

--- a/tests/test_import_whisper.py
+++ b/tests/test_import_whisper.py
@@ -20,7 +20,6 @@ import shutil
 import time
 import unittest
 
-import mock
 import whisper
 
 from biggraphite.cli import import_whisper
@@ -34,6 +33,7 @@ class TestMain(bg_test_utils.TestCaseWithFakeAccessor):
 
     def setUp(self):
         super(TestMain, self).setUp()
+        self.patch_accessor()
         self.tempdir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.tempdir)
 
@@ -62,15 +62,14 @@ class TestMain(bg_test_utils.TestCaseWithFakeAccessor):
         self.assertEqual(points, points_again)
 
     def _call_main(self):
-        with mock.patch('biggraphite.accessor.Accessor', return_value=self.accessor):
-            import_whisper.main([
-                "--quiet",
-                "--keyspace", "keyspace",
-                "--port", "42",
-                "--process", "1",
-                self.tempdir,
-                "testhost1", "testhost2",
-            ])
+        import_whisper.main([
+            "--quiet",
+            "--keyspace", "keyspace",
+            "--port", "42",
+            "--process", "1",
+            self.tempdir,
+            "testhost1", "testhost2",
+        ])
 
 
 if __name__ == "__main__":

--- a/tox.ini
+++ b/tox.ini
@@ -17,31 +17,34 @@ envlist = {py27,pypy}-coverage,pylama
 [testenv]
 passenv=
     CASSANDRA_HOME
-deps = coverage
-install_command = pip install \
-                  --install-option='--install-scripts={envbindir}' \
-                  --install-option='--install-lib={envsitepackagesdir}' \
-                  --install-option='--install-data={envdir}/lib/graphite' \
-                  -r '{toxinidir}/requirements.txt' \
-                  -r '{toxinidir}/tests-requirements.txt' \
-                  {opts} {packages}
+setenv=
+    # Prevents graphite from trying to install itself in /opt/
+    GRAPHITE_NO_PREFIX=true
 
 
 [base-coverage]
 commands = coverage erase
-           coverage run --omit=biggraphite/test_utils.py -m unittest discover
+           coverage run --omit=biggraphite/test_utils.py \
+	   -m unittest discover --failfast --verbose --catch
            coverage report
+deps =
+     coverage
+     -r{toxinidir}/requirements.txt
+     -r{toxinidir}/tests-requirements.txt
 
 
 [testenv:py27-coverage]
 commands={[base-coverage]commands}
+deps={[base-coverage]deps}
 
 
 [testenv:pypy-coverage]
 commands={[base-coverage]commands}
+deps={[base-coverage]deps}
 
 
 [testenv:pylama]
-basepython = python2.7
+basepython = pypy
 commands = pylama biggraphite tests *.py
 deps = pylama
+sitepackages = true


### PR DESCRIPTION
- tox only installs minimal dependancies for each env
- removed --install-option, allowing reuse of wheels
- If CASSANDRA_HOME is not set, corresponding (slow) tests are skipped
  allowing to run lightweight tests quickly.
- If a test fail, cancel the whole run (so Travis replies faster)
- test_carbon uses FakeAccessor, so accessor tests are now the only
  tests to run with a real Cassandra

Also makes some small improvements, like making FakeAccessor and
Accessor more similar and raising test coverage a bit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/biggraphite/21)
<!-- Reviewable:end -->
