### PR TITLE
Fix memory leak and bug

### DIFF
--- a/biggraphite/metadata_cache.py
+++ b/biggraphite/metadata_cache.py
@@ -27,6 +27,7 @@ from __future__ import print_function
 
 import os
 from os import path as os_path
+import sys
 import threading
 
 import lmdb
@@ -83,8 +84,12 @@ class DiskCache(object):
             os.makedirs(self.__path)
         except OSError:
             pass  # Directory already exists
+        map_size = 1024*1024*1024  # 1G on 32 bits systems
+        if sys.maxsize > 2**32:
+            map_size *= 16  # 16G on 64 bits systems
         self.__env = lmdb.open(
             self.__path,
+            map_size=map_size,
             # Only one sync per transaction, system crash can undo a transaction.
             metasync=False,
             # Use mmap()

--- a/biggraphite/metadata_cache.py
+++ b/biggraphite/metadata_cache.py
@@ -128,7 +128,7 @@ class DiskCache(object):
             with self.__json_cache_lock:
                 metadata = self.__json_cache.get(metadata_str)
                 if not metadata:
-                    metadata = bg_accessor.MetricMetadata.from_json(metadata_str)
+                    metadata = bg_accessor.MetricMetadata.from_json(metric_name, metadata_str)
                     self.__json_cache[metadata_str] = metadata
             return metadata
         else:
@@ -145,5 +145,6 @@ class DiskCache(object):
             # Do not cache absent metrics, they will probably soon be created.
             return None
         metadata_json = metadata.as_json()
+        name = metadata.name
         with self.__env.begin(self.__metric_to_metadata_db, write=True) as txn:
-            txn.put(metadata.name, metadata_json, dupdata=False, overwrite=True)
+            txn.put(name, metadata_json, dupdata=False, overwrite=True)

--- a/tests/test_metadata_cache.py
+++ b/tests/test_metadata_cache.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding: utf-8
 # Copyright 2016 Criteo
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -54,6 +55,10 @@ class TestGraphiteUtilsInternals(bg_test_utils.TestCaseWithFakeAccessor):
         first = self.metadata_cache.get_metric(_TEST_METRIC.name)
         second = self.metadata_cache.get_metric(_TEST_METRIC.name)
         self.assertIs(first, second)
+
+    def test_unicode(self):
+        metric = bg_accessor.MetricMetadata(u"a.b.testé")
+        self.metadata_cache.create_metric(metric)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- We were limited to 10M of local cache
- LMDB won't accept unicode objects, so encode metric names to
  UTF-8 (probably safer anyway)
- we cache decoded jsons metadata but they included metric names, taking
  quite some memory (while the idea behind caching is that there are few
  retentions policies in use at any given time)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/biggraphite/25)
<!-- Reviewable:end -->
