### PR TITLE
Accessor uses Metric instead of names

### DIFF
--- a/biggraphite/cli/import_whisper.py
+++ b/biggraphite/cli/import_whisper.py
@@ -73,7 +73,6 @@ class _Worker(object):
             for a in info["archives"]
         ]
         return bg_accessor.MetricMetadata(
-            name=metric_name,
             carbon_aggregation=info["aggregationMethod"],
             carbon_retentions=retentions,
             carbon_xfilesfactor=info["xFilesFactor"],
@@ -126,8 +125,9 @@ class _Worker(object):
         metric_name = metric_name_from_wsp(self._opts.root_directory, path)
         points = self._read_points(path)
         meta = self._read_metadata(metric_name, path)
-        self._accessor.create_metric(meta)
-        self._accessor.insert_points(metric_name, points)
+        metric = bg_accessor.Metric(metric_name, meta)
+        self._accessor.create_metric(metric)
+        self._accessor.insert_points(metric, points)
         return len(points)
 
 

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -21,7 +21,7 @@ import statistics
 from biggraphite import accessor as bg_accessor
 from biggraphite import test_utils as bg_test_utils
 
-_METRIC = "test.metric"
+_METRIC = bg_test_utils.make_metric("test.metric")
 
 # Points test query.
 _QUERY_RANGE = 3600
@@ -45,7 +45,6 @@ class TestMetricMetadata(unittest.TestCase):
     def _make_metric_metadata(self, **kwargs):
         """Like bg_accessor.MetricMetadata but with different default values."""
         kwargs.setdefault("carbon_retentions", self._RETENTIONS)
-        kwargs.setdefault("name", _METRIC)
         return bg_accessor.MetricMetadata(**kwargs)
 
     def test_carbon_aggregations(self):
@@ -79,8 +78,21 @@ class TestMetricMetadata(unittest.TestCase):
         self.assertFalse(m_explicit.carbon_aggregate_points(points_duration, points=points[:2]))
         self.assertTrue(m_explicit.carbon_aggregate_points(points_duration, points=points[:3]))
 
-        m_default = bg_accessor.MetricMetadata(_METRIC)
+        m_default = bg_accessor.MetricMetadata()
         self.assertEqual(0.5, m_default.carbon_xfilesfactor)
+
+    def test_setattr(self):
+        m = self._make_metric_metadata()
+        self.assertTrue(hasattr(m, "carbon_xfilesfactor"))
+        self.assertRaises(AttributeError, setattr, m, "carbon_xfilesfactor", 0.5)
+
+
+class TestMetric(unittest.TestCase):
+
+    def test_dir(self):
+        metric = bg_test_utils.make_metric("a.b.c")
+        self.assertIn("name", dir(metric))
+        self.assertIn("carbon_xfilesfactor", dir(metric))
 
 
 class TestAccessorWithCassandra(bg_test_utils.TestCaseWithAccessor):
@@ -98,10 +110,11 @@ class TestAccessorWithCassandra(bg_test_utils.TestCaseWithAccessor):
         self.assertFalse(self.accessor.is_connected)
 
     def test_fetch_empty(self):
+        no_such_metric = bg_test_utils.make_metric("no.such.metric")
         self.accessor.insert_points(_METRIC, _POINTS)
         self.accessor.drop_all_metrics()
         self.assertFalse(
-            self.accessor.fetch_points("no.such.metric", _POINTS_START, _POINTS_END, step=1))
+            self.accessor.fetch_points(no_such_metric, _POINTS_START, _POINTS_END, step=1))
         self.assertFalse(
             self.accessor.fetch_points(_METRIC, _POINTS_START, _POINTS_END, step=1))
 
@@ -139,8 +152,8 @@ class TestAccessorWithCassandra(bg_test_utils.TestCaseWithAccessor):
 
     def test_glob_metrics(self):
         for name in "a", "a.a", "a.b", "a.a.a", "x.y.z":
-            meta = bg_accessor.MetricMetadata(name)
-            self.accessor.create_metric(meta)
+            metric = bg_test_utils.make_metric(name)
+            self.accessor.create_metric(metric)
 
         def assert_find(glob, expected_matches):
             # Check we can find the matches of a glob
@@ -159,8 +172,8 @@ class TestAccessorWithCassandra(bg_test_utils.TestCaseWithAccessor):
 
     def test_glob_directories(self):
         for name in "a", "a.b", "x.y.z":
-            meta = bg_accessor.MetricMetadata(name)
-            self.accessor.create_metric(meta)
+            metric = bg_test_utils.make_metric(name)
+            self.accessor.create_metric(metric)
 
         def assert_find(glob, expected_matches):
             # Check we can find the matches of a glob
@@ -178,17 +191,18 @@ class TestAccessorWithCassandra(bg_test_utils.TestCaseWithAccessor):
         assert_find("*", [])
 
     def test_create_metrics(self):
-        metric_data = {
-            "name": "a.b.c.d.e.f",
+        meta_dict = {
             "carbon_aggregation": "last",
             "carbon_retentions": [[1, 60], [60, 3600]],
             "carbon_xfilesfactor": 0.3,
         }
-        metric = bg_accessor.MetricMetadata(**metric_data)
+        metric = bg_test_utils.make_metric("a.b.c.d.e.f", **meta_dict)
+
         self.accessor.create_metric(metric)
-        metric_again = self.accessor.get_metric(metric_data['name'])
-        for k, v in metric_data.iteritems():
-            self.assertEqual(v, getattr(metric_again, k))
+        metric_again = self.accessor.get_metric(metric.name)
+        self.assertEqual(metric.name, metric_again.name)
+        for k, v in meta_dict.iteritems():
+            self.assertEqual(v, getattr(metric_again.metadata, k))
 
 
 if __name__ == "__main__":

--- a/tests/test_graphite.py
+++ b/tests/test_graphite.py
@@ -18,7 +18,6 @@ from __future__ import print_function
 
 import unittest
 
-from biggraphite import accessor as bg_accessor
 from biggraphite import test_utils as bg_test_utils
 from biggraphite.plugins import graphite as bg_graphite
 
@@ -59,15 +58,12 @@ class TestReader(bg_test_utils.TestCaseWithFakeAccessor):
     _POINTS = _make_easily_queryable_points(
         start=_POINTS_START, end=_POINTS_END, period=_PRECISION,
     )
+    _METRIC = bg_test_utils.make_metric(_METRIC_NAME, carbon_retentions=_RETENTIONS)
 
     def setUp(self):
         super(TestReader, self).setUp()
-        meta = bg_accessor.MetricMetadata(
-            _METRIC_NAME,
-            carbon_retentions=self._RETENTIONS,
-        )
-        self.accessor.create_metric(meta)
-        self.accessor.insert_points(_METRIC_NAME, self._POINTS)
+        self.accessor.create_metric(self._METRIC)
+        self.accessor.insert_points(self._METRIC, self._POINTS)
         self.reader = bg_graphite.Reader(self.accessor, self.metadata_cache, _METRIC_NAME)
 
     def test_fresh_read(self):
@@ -109,9 +105,9 @@ class TestFinder(bg_test_utils.TestCaseWithFakeAccessor):
 
     def setUp(self):
         super(TestFinder, self).setUp()
-        for metric in "a", "a.a", "a.b.c", "x.y":
-            meta = bg_accessor.MetricMetadata(metric)
-            self.accessor.create_metric(meta)
+        for metric_name in "a", "a.a", "a.b.c", "x.y":
+            metric = bg_test_utils.make_metric(metric_name)
+            self.accessor.create_metric(metric)
         self.finder = bg_graphite.Finder(
             accessor=self.accessor,
             metadata_cache=self.metadata_cache,

--- a/tests/test_graphite_utils.py
+++ b/tests/test_graphite_utils.py
@@ -17,7 +17,6 @@ from __future__ import print_function
 
 import unittest
 
-from biggraphite import accessor as bg_accessor
 from biggraphite import test_utils as bg_test_utils
 from biggraphite import graphite_utils as bg_gu
 
@@ -83,8 +82,8 @@ class TestGraphiteUtils(bg_test_utils.TestCaseWithFakeAccessor):
     def test_glob(self):
         self.addCleanup(self.accessor.drop_all_metrics)
         for name in "a", "a.b.c", "a.b.d", "x.y.c", "a.a.a":
-            meta = bg_accessor.MetricMetadata(name)
-            self.accessor.create_metric(meta)
+            metric = bg_test_utils.make_metric(name)
+            self.accessor.create_metric(metric)
         self.assertEqual((["a"], ["a", "x"]), bg_gu.glob(self.accessor, "*"))
         self.assertEqual((["a.b.c", "x.y.c"], []), bg_gu.glob(self.accessor, "*.*.c"))
         self.assertEqual((["a.a.a", "a.b.c", "a.b.d"], []), bg_gu.glob(self.accessor, "a.*.*"))

--- a/tests/test_import_whisper.py
+++ b/tests/test_import_whisper.py
@@ -67,12 +67,12 @@ class TestMain(bg_test_utils.TestCaseWithFakeAccessor):
 
         self._call_main()
 
-        meta = self.accessor.get_metric(metric)
-        self.assertTrue(meta)
-        self.assertEqual(meta.name, metric)
-        self.assertEqual(meta.carbon_aggregation, aggregation_method)
-        self.assertEqual(meta.carbon_xfilesfactor, xfilesfactor)
-        self.assertEqual(meta.carbon_retentions, retentions)
+        metric = self.accessor.get_metric(metric)
+        self.assertTrue(metric)
+        self.assertEqual(metric.name, metric.name)
+        self.assertEqual(metric.carbon_aggregation, aggregation_method)
+        self.assertEqual(metric.carbon_xfilesfactor, xfilesfactor)
+        self.assertEqual(metric.carbon_retentions, retentions)
 
         points_again = self.accessor.fetch_points(metric, time_from, time_to, step=1)
         self.assertEqual(points[-high_precision_duration:], points_again)

--- a/tests/test_metadata_cache.py
+++ b/tests/test_metadata_cache.py
@@ -17,10 +17,9 @@ from __future__ import print_function
 
 import unittest
 
-from biggraphite import accessor as bg_accessor
 from biggraphite import test_utils as bg_test_utils
 
-_TEST_METRIC = bg_accessor.MetricMetadata("a.b.c")
+_TEST_METRIC = bg_test_utils.make_metric("a.b.c")
 
 
 class TestGraphiteUtilsInternals(bg_test_utils.TestCaseWithFakeAccessor):
@@ -54,11 +53,11 @@ class TestGraphiteUtilsInternals(bg_test_utils.TestCaseWithFakeAccessor):
         self.metadata_cache.create_metric(_TEST_METRIC)
         first = self.metadata_cache.get_metric(_TEST_METRIC.name)
         second = self.metadata_cache.get_metric(_TEST_METRIC.name)
-        self.assertIs(first, second)
+        self.assertIs(first.metadata, second.metadata)
 
     def test_unicode(self):
         metric_name = u"a.b.testé"
-        metric = bg_accessor.MetricMetadata(metric_name)
+        metric = bg_test_utils.make_metric(metric_name)
         self.metadata_cache.create_metric(metric)
         self.metadata_cache.get_metric(metric_name)
 


### PR DESCRIPTION
So that downsampling can happen at write and aggregation server-side,
the Accessor needs to have metadata when it reads/writes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/biggraphite/34)
<!-- Reviewable:end -->
