### PR TITLE
Make aggregator an enum and retention an object

### DIFF
--- a/biggraphite/accessor.py
+++ b/biggraphite/accessor.py
@@ -18,8 +18,12 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import abc
+import array
 import codecs
+import enum
 import json
+import math
+import re
 import threading
 
 
@@ -36,6 +40,8 @@ class InvalidArgumentError(Error):
 
 
 _UTF8_CODEC = codecs.getencoder('utf8')
+
+_NAN = float("nan")
 
 
 def encode_metric_name(name):
@@ -65,6 +71,276 @@ def round_up(rounded, divider):
     return int(rounded + divider - 1) // divider * divider
 
 
+@enum.unique
+class Aggregator(enum.Enum):
+    """Represents one of the known aggregations."""
+
+    minimum = "min"
+    maximum = "max"
+    total = "sum"
+    average = "avg"
+    last = "last"
+
+    def __init__(self, carbon_name):
+        """Set attributes."""
+        self.carbon_name = carbon_name
+        self._downsample = getattr(self, "_downsample_" + self.name)
+        self._merge = getattr(self, "_merge_" + self.name)
+
+    def merge(self, old, old_weight, fresh):
+        """Merge fresh values from a finer grained Stage in a coarser Stage.
+
+        For example: old=DAY_DATA, old_weight=24, fresh=CURRENT_HOUR_DATA.
+        NaNs are ignored: if one of old or fresh is NaN, the other is returned.
+
+        Args:
+          old: A float, the value for the coarser, older Stage.
+          old_weight: Weight of old relative to weight of fresh.
+           Only used when computing averages.
+          fresh: A float, the value for the less coarse, newer Stage.
+
+        Returns:
+          The merged value, NaN if both are NaN.
+        """
+        if math.isnan(fresh):
+            return old
+        if math.isnan(old):
+            return fresh
+        return self._merge(old, old_weight, fresh)
+
+    def _merge_average(self, old, old_weight, fresh):
+        return (old * old_weight + fresh) / float(old_weight + 1)
+
+    def _merge_last(self, old, old_weight, fresh):
+        return fresh
+
+    def _merge_maximum(self, old, old_weight, fresh):
+        return max(old, fresh)
+
+    def _merge_minimum(self, old, old_weight, fresh):
+        return min(old, fresh)
+
+    def _merge_total(self, old, old_weight, fresh):
+        return old + fresh
+
+    def downsample(self, values, newest_first):
+        """Aggregate together values of a given stage.
+
+        Args:
+          values: values to aggregate as float from oldest to most recent (unless
+            newest_first is True).
+          newest_first: if True, values are in reverse order.
+
+        Returns:
+          The downsampled value, NaN if values is empty or all values are NaN.
+        """
+        if not values:
+            return _NAN
+        return self._downsample(values, newest_first)
+
+    def _downsample_average(self, values, values_newest_first):
+        total, count = self.__sum_and_count(values)
+        return total / count
+
+    def _downsample_last(self, values, values_newest_first):
+        if not values_newest_first:
+            values = reversed(values)
+        for v in values:
+            if not math.isnan(v):
+                return v
+        return _NAN
+
+    def _downsample_maximum(self, values, values_newest_first):
+        _, maximum = self.__min_and_max(values)
+        return maximum
+
+    def _downsample_minimum(self, values, values_newest_first):
+        minimum, _ = self.__min_and_max(values)
+        return minimum
+
+    def _downsample_total(self, values, values_newest_first):
+        total, _ = self.__sum_and_count(values)
+        return total
+
+    @classmethod
+    def from_carbon_name(cls, name):
+        """Make an instance from a carbon-like name."""
+        if not name:
+            return None
+        try:
+            return cls(name)
+        except ValueError:
+            raise InvalidArgumentError("Unknown carbon aggregation: %s" % name)
+
+    @classmethod
+    def from_config_name(cls, name):
+        """Make an instance from a BigGraphite name."""
+        if not name:
+            return None
+        try:
+            return cls[name]
+        except KeyError:
+            raise InvalidArgumentError("Unknown BG aggregator: %s" % name)
+
+    @staticmethod
+    def __sum_and_count(values):
+        total = 0.0
+        count = 0
+        for v in values:
+            if math.isnan(v):
+                continue
+            total += v
+            count += 1
+        if not count:
+            return _NAN, _NAN
+        return total, count
+
+    @staticmethod
+    def __min_and_max(values):
+        minimum = None
+        maximum = None
+        for v in values:
+            if math.isnan(v):
+                continue
+            if minimum is None:
+                maximum = v
+                minimum = v
+            elif maximum < v:
+                maximum = v
+            elif minimum > v:
+                minimum = v
+        if minimum is None:
+            assert maximum is None
+            return _NAN, _NAN
+        return minimum, maximum
+
+
+class Stage(object):
+    """One of the element of a retention policy.
+
+    A stage means "keep that many points with that precision".
+    Precision is the amount of time a point covers, measured in seconds.
+    """
+
+    __slots__ = ("points", "precision", )
+
+    # Parses the values of as_string into points and precision group
+    _STR_RE = re.compile(r"^(?P<points>[\d]+)\*(?P<precision>[\d]+)s$")
+
+    def __init__(self, points, precision):
+        """Set attributes."""
+        self.points = int(points)
+        self.precision = int(precision)
+
+    def __str__(self):
+        return self.as_string
+
+    def __eq__(self, other):
+        if not isinstance(other, Stage):
+            return False
+        return self.points == other.points and self.precision == other.precision
+
+    def __ne__(self, other):
+        return not (self == other)
+
+    @property
+    def duration(self):
+        """The duration of this stage in seconds."""
+        return self.points * self.precision
+
+    @property
+    def as_string(self):
+        """A string like "${POINTS}*${PRECISION}s"."""
+        return "{}*{}s".format(self.points, self.precision)
+
+    @classmethod
+    def from_string(cls, s):
+        """Parse results of as_string into an instance."""
+        match = cls._STR_RE.match(s)
+        if not match:
+            raise InvalidArgumentError("Invalid retention: '%s'" % s)
+        groups = match.groupdict()
+        return cls(
+            points=int(groups['points']),
+            precision=int(groups['precision']),
+        )
+
+    def epoch(self, timestamp):
+        """Return time elapsed since Unix epoch in count of self.duration.
+
+        A "stage epoch" is a range of timestamps: [N*stage_duration, (N+1)*stage_duration[
+        This function returns N.
+
+        Args:
+          timestamp: A timestamp in seconds.
+        """
+        return int(timestamp / self.duration)
+
+
+class Retention(object):
+    """A retention policy, made of 0 or more Stages."""
+
+    __slots__ = ("stages", )
+
+    def __init__(self, stages):
+        """Set self.stages ."""
+        prev = None
+        for s in stages:
+            if prev and s.precision % prev.precision:
+                raise InvalidArgumentError("precision of %s must be a multiple of %s" % (s, prev))
+            if prev and prev.duration >= s.duration:
+                raise InvalidArgumentError("duration of %s must be lesser than %s" % (s, prev))
+            prev = s
+        self.stages = tuple(stages)
+
+    def __eq__(self, other):
+        if not isinstance(other, Retention):
+            return False
+        return self.stages == other.stages
+
+    def __ne__(self, other):
+        return not (self == other)
+
+    @property
+    def as_string(self):
+        """Return strings like "60*60s:24*3600s"."""
+        return ":".join(s.as_string for s in self.stages)
+
+    @classmethod
+    def from_string(cls, string):
+        """Parse results of as_string into an instance.
+
+        Args:
+          string: A string like "60*60s:24*3600s"
+        """
+        if string:
+            stages = [Stage.from_string(s) for s in string.split(":")]
+        else:
+            stages = []
+        return cls(stages=stages)
+
+    @property
+    def duration(self):
+        """Return the maximum duration of all stages."""
+        if not self.stages:
+            return 0
+        return self.stages[-1].duration
+
+    def __getitem__(self, n):
+        """Return the n-th stage."""
+        return self.stages[n]
+
+    @classmethod
+    def from_carbon(cls, l):
+        """Make new instance from list of (precision, points).
+
+        Note that precision is first, unlike in Stage.__init__
+        """
+        stages = [Stage(points=points, precision=precision)
+                  for precision, points in l]
+        return cls(stages)
+
+
 class MetricMetadata(object):
     """Represents all information about a metric except its name.
 
@@ -72,26 +348,26 @@ class MetricMetadata(object):
     """
 
     __slots__ = (
-        "carbon_aggregation", "carbon_highest_precision",
-        "carbon_retentions", "carbon_xfilesfactor",
+        "aggregator", "retention", "carbon_xfilesfactor",
     )
 
-    _DEFAULT_AGGREGATION = "average"
-    _DEFAULT_RETENTIONS = [[1, 24*3600]]  # One second for one day
+    _DEFAULT_AGGREGATOR = Aggregator.average
+    _DEFAULT_RETENTION = Retention.from_string("86400*1s")
     _DEFAULT_XFILESFACTOR = 0.5
 
-    def __init__(self, carbon_aggregation=None, carbon_retentions=None, carbon_xfilesfactor=None):
+    def __init__(self, aggregator=None, retention=None, carbon_xfilesfactor=None):
         """Record its arguments."""
-        self.carbon_aggregation = carbon_aggregation or self._DEFAULT_AGGREGATION
-        self.carbon_retentions = carbon_retentions or self._DEFAULT_RETENTIONS
-        self.carbon_xfilesfactor = carbon_xfilesfactor
-        if self.carbon_xfilesfactor is None:
+        self.aggregator = aggregator or self._DEFAULT_AGGREGATOR
+        assert isinstance(self.aggregator, Aggregator), self.aggregator
+        self.retention = retention or self._DEFAULT_RETENTION
+        if carbon_xfilesfactor is None:
             self.carbon_xfilesfactor = self._DEFAULT_XFILESFACTOR
-        self.carbon_highest_precision = self.carbon_retentions[0][0]
+        else:
+            self.carbon_xfilesfactor = carbon_xfilesfactor
 
     def __setattr__(self, name, value):
-        # carbon_highest_precision is the last attribute __init__ sets.
-        if hasattr(self, "carbon_highest_precision"):
+        # carbon_xfilesfactor is the last attribute __init__ sets.
+        if hasattr(self, "carbon_xfilesfactor"):
             raise AttributeError("can't set attribute")
         super(MetricMetadata, self).__setattr__(name, value)
 
@@ -102,8 +378,8 @@ class MetricMetadata(object):
     def as_string_dict(self):
         """Turn an instance into a dict of string to string."""
         return {
-            "carbon_aggregation": self.carbon_aggregation,
-            "carbon_retentions": json.dumps(self.carbon_retentions),
+            "aggregator": self.aggregator.name,
+            "retention": self.retention.as_string,
             "carbon_xfilesfactor": "%f" % self.carbon_xfilesfactor,
         }
 
@@ -116,39 +392,10 @@ class MetricMetadata(object):
     def from_string_dict(cls, d):
         """Turn a dict of string to string into a MetricMetadata."""
         return cls(
-            carbon_aggregation=d.get("carbon_aggregation"),
-            carbon_retentions=json.loads(d.get("carbon_retentions")),
+            aggregator=Aggregator.from_config_name(d.get("aggregator")),
+            retention=Retention.from_string(d.get("retention")),
             carbon_xfilesfactor=float(d.get("carbon_xfilesfactor")),
         )
-
-    def carbon_aggregate_points(self, time_span, points):
-        """"An aggregator function suitable for Accessor.fetch().
-
-        Args:
-          time_span: the duration for which we are aggregating, in seconds.
-            For example, if points are meant to represent an hour, the value is 3600.
-          points: values to aggregate as float from most recent to oldest
-
-        Returns:
-          A float, or None to reject the points.
-        """
-        # TODO: Handle precomputation of aggregates.
-        assert time_span
-        coverage = len(points) * self.carbon_highest_precision / float(time_span)
-        if not points or coverage < self.carbon_xfilesfactor:
-            return None
-        if self.carbon_aggregation == "average":
-            return float(sum(points)) / len(points)
-        if self.carbon_aggregation == "last":
-            # Points are stored in descending order, the "last" is actually the first
-            return points[0]
-        if self.carbon_aggregation == "min":
-            return min(points)
-        if self.carbon_aggregation == "max":
-            return max(points)
-        if self.carbon_aggregation == "sum":
-            return sum(points)
-        raise InvalidArgumentError("Unknown aggregation method: %s" % self.carbon_aggregation)
 
 
 class Metric(object):
@@ -340,7 +587,7 @@ class Accessor(object):
 
 
 class PointGrouper(object):
-    """Helper for client-side aggregation.
+    """Helper for client-side aggregator.
 
     It hardcodes a knowledge of how Casssandra results are returned together, this should be
     abstracted away if more datastores do client-side agregation.
@@ -350,13 +597,13 @@ class PointGrouper(object):
         """Constructor for PointGrouper.
 
         Args:
-          metric: The metric for which to insert point.
+          metric: The metric for which to group values.
           time_start_ms: timestamp in second from the Epoch as an int,
             inclusive,  must be a multiple of step
           time_end_ms: timestamp in second from the Epoch as an int,
             exclusive, must be a multiple of step
           step_ms: time delta in seconds as an int, must be > 0
-          query_results: query results to fetch point from.
+          query_results: query results to fetch values from.
         """
         self.metric = metric
         self.time_start_ms = time_start_ms
@@ -364,32 +611,33 @@ class PointGrouper(object):
         self.step_ms = step_ms
         self.query_results = query_results
 
-        self.current_points = []
+        self.current_values = array.array("d")
         self.current_timestamp_ms = None
 
     def __iter__(self):
-        return self.generate_points()
+        return self.generate_values()
 
-    def run_aggregation(self):
-        """Aggregate points in current_points.
+    def run_aggregator(self):
+        """Aggregate values in current_values.
 
         This will skip the first point and return (None, None)
         if the function doesn't generate any aggregated point.
         """
         # This is the first point we encounter, do not emit it on its own,
-        # rather wait until we have found points fitting in the next period.
+        # rather wait until we have found values fitting in the next period.
         ret = (None, None)
         if self.current_timestamp_ms is None:
             return ret
-        aggregate = self.metric.metadata.carbon_aggregate_points(
-            self.step_ms / 1000.0, self.current_points)
+        aggregate = self.metric.metadata.aggregator.downsample(
+            values=self.current_values, newest_first=True,
+        )
         if aggregate is not None:
             ret = (self.current_timestamp_ms / 1000.0, aggregate)
-            del self.current_points[:]
+            del self.current_values[:]
         return ret
 
-    def generate_points(self):
-        """Generator function ton consume query_results and produce points."""
+    def generate_values(self):
+        """Generator function, consume query_results and produce values."""
         first_exc = None
 
         for successfull, rows_or_exception in self.query_results:
@@ -405,15 +653,15 @@ class PointGrouper(object):
                 timestamp_ms = round_down(timestamp_ms, self.step_ms)
 
                 if self.current_timestamp_ms != timestamp_ms:
-                    ts, point = self.run_aggregation()
+                    ts, point = self.run_aggregator()
                     if ts is not None:
                         yield (ts, point)
 
                     self.current_timestamp_ms = timestamp_ms
 
-                self.current_points.append(row[2])
+                self.current_values.append(row[2])
 
-        ts, point = self.run_aggregation()
+        ts, point = self.run_aggregator()
         if ts is not None:
             yield (ts, point)
 

--- a/biggraphite/cli/import_whisper.py
+++ b/biggraphite/cli/import_whisper.py
@@ -68,13 +68,14 @@ class _Worker(object):
     @staticmethod
     def _read_metadata(metric_name, path):
         info = whisper.info(path)
-        retentions = [
-            (a["secondsPerPoint"], a["points"])
+        retentions = bg_accessor.Retention([
+            bg_accessor.Stage(precision=a["secondsPerPoint"], points=a["points"])
             for a in info["archives"]
-        ]
+        ])
+        aggregator = bg_accessor.Aggregator.from_carbon_name(info["aggregationMethod"])
         return bg_accessor.MetricMetadata(
-            carbon_aggregation=info["aggregationMethod"],
-            carbon_retentions=retentions,
+            aggregator=aggregator,
+            retention=retentions,
             carbon_xfilesfactor=info["xFilesFactor"],
         )
 

--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -91,6 +91,7 @@ _SETUP_CQL_DATAPOINTS = str(
     "  time_start_ms bigint,"
     "  time_offset_ms int,"
     "  value double,"
+    "  count int,"
     "  PRIMARY KEY ((metric, time_start_ms), time_offset_ms)"
     ")"
     "  WITH CLUSTERING ORDER BY (time_offset_ms DESC)"
@@ -165,11 +166,11 @@ class _CassandraAccessor(bg_accessor.Accessor):
         if not skip_schema_upgrade:
             self._upgrade_schema()
         self.__insert_statement = self.__session.prepare(
-            "INSERT INTO datapoints (metric, time_start_ms, time_offset_ms, value)"
-            " VALUES (?, ?, ?, ?);")
+            "INSERT INTO datapoints (metric, time_start_ms, time_offset_ms, value, count)"
+            " VALUES (?, ?, ?, ?, 1);")
         self.__insert_statement.consistency_level = cassandra.ConsistencyLevel.ONE
         self.__select_statement = self.__session.prepare(
-            "SELECT time_start_ms, time_offset_ms, value FROM datapoints"
+            "SELECT time_start_ms, time_offset_ms, value, count FROM datapoints"
             " WHERE metric=? AND time_start_ms=? "
             " AND time_offset_ms >= ? AND time_offset_ms < ? "
             " ORDER BY time_offset_ms;")

--- a/biggraphite/plugins/carbon.py
+++ b/biggraphite/plugins/carbon.py
@@ -72,8 +72,8 @@ class BigGraphiteDatabase(database.TimeSeriesDatabase):
 
     def create(self, metric_name, retentions, xfilesfactor, aggregation_method):
         metadata = accessor.MetricMetadata(
-            carbon_aggregation=aggregation_method,
-            carbon_retentions=retentions,
+            aggregator=accessor.Aggregator.from_carbon_name(aggregation_method),
+            retention=accessor.Retention.from_carbon(retentions),
             carbon_xfilesfactor=xfilesfactor,
         )
         metric = accessor.Metric(metric_name, metadata)
@@ -86,8 +86,8 @@ class BigGraphiteDatabase(database.TimeSeriesDatabase):
         metadata = self._cache.get_metric(metric_name=metric_name)
         if not metadata:
             raise ValueError("%s: No such metric" % metric_name)
-        assert metadata.carbon_aggregation
-        return metadata.carbon_aggregation
+        assert metadata.aggregator.carbon_name
+        return metadata.aggregator.carbon_name
 
     def setMetadata(self, metric_name, key, value):
         old_value = self.getMetadata(metric_name, key)

--- a/biggraphite/test_utils.py
+++ b/biggraphite/test_utils.py
@@ -101,11 +101,14 @@ def prepare_graphite_imports():
                 sys.path.insert(0, path)
 
 
-def make_metric(name, metadata=None, *args, **kwargs):
+def make_metric(name, metadata=None, **kwargs):
     """Create a bg_accesor.Metric with specified metadata."""
-    assert not args
+    retention = kwargs.get("retention")
+    if isinstance(retention, basestring):
+        kwargs["retention"] = bg_accessor.Retention.from_string(retention)
     if metadata:
         assert isinstance(metadata, bg_accessor.MetricMetadata)
+        assert not kwargs
     else:
         metadata = bg_accessor.MetricMetadata(**kwargs)
     return bg_accessor.Metric(name, metadata)
@@ -198,8 +201,8 @@ class FakeAccessor(bg_accessor.Accessor):
         points = self._metric_to_points[metric.name]
         rows = []
         for ts in points.irange(time_start, time_end):
-            # A row is time_base_ms, time_offset_ms, value
-            row = (ts * 1000.0, 0, float(points[ts]))
+            # A row is time_base_ms, time_offset_ms, value, count
+            row = (ts * 1000.0, 0, float(points[ts]), 1)
             rows.append(row)
         query_results = [(True, rows)]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 cassandra-driver
+enum34
 lmdb
 progressbar2
 sortedcontainers

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 from __future__ import print_function
 
+import math
 import unittest
 
 import mock
@@ -22,54 +23,136 @@ from biggraphite import accessor as bg_accessor
 from biggraphite import test_utils as bg_test_utils
 
 _METRIC = bg_test_utils.make_metric("test.metric")
+_NAN = float("nan")
+
+
+class TestAggregator(unittest.TestCase):
+
+    # This does not test seralisation as TestRetention exercise that already.
+
+    def test_downsample(self):
+        values = [_NAN, 0, 1, _NAN, 2, 3, _NAN]
+        expectations = (
+            ("average", 1.5),
+            ("last", 0),  # Values from most recent to oldest
+            ("minimum", 0),
+            ("maximum", 3),
+            ("total", 6),
+        )
+        for name, value_expected in expectations:
+            aggregator = bg_accessor.Aggregator.from_config_name(name)
+            downsampled = aggregator.downsample(values=values, newest_first=True)
+            self.assertEqual(value_expected, downsampled)
+
+    def test_downsample_nan(self):
+        values = [_NAN, _NAN]
+        for aggregator in bg_accessor.Aggregator:
+            downsampled = aggregator.downsample(values, newest_first=True)
+            self.assertTrue(math.isnan(downsampled), aggregator)
+
+    def test_downsample_newest_last(self):
+        aggregator = bg_accessor.Aggregator.last
+        values = [10, 20, _NAN, ]
+        downsampled = aggregator.downsample(values=values, newest_first=False)
+        self.assertEqual(20, downsampled)
+
+    def test_downsample_no_values(self):
+        aggregator = bg_accessor.Aggregator.last
+        downsampled = aggregator.downsample(values=[], newest_first=False)
+        self.assertTrue(math.isnan(downsampled))
+
+    def test_merge(self):
+        old = 10
+        old_weight = 10
+        fresh = 120
+        expectations = (
+            ("average", 20),
+            ("last", 120),
+            ("minimum", 10),
+            ("maximum", 120),
+            ("total", 130),
+        )
+        for name, value_expected in expectations:
+            aggregator = bg_accessor.Aggregator.from_config_name(name)
+            merged = aggregator.merge(old, old_weight, fresh)
+            self.assertEqual(value_expected, merged)
+
+    def test_merge_nans(self):
+        aggregator = bg_accessor.Aggregator.average
+        self.assertEqual(10, aggregator.merge(old=10, old_weight=1, fresh=_NAN))
+        self.assertEqual(10, aggregator.merge(old=_NAN, old_weight=1, fresh=10))
+
+    def test_config_names(self):
+        self.assertEqual(
+            bg_accessor.Aggregator.from_carbon_name("avg"),
+            bg_accessor.Aggregator.average,
+        )
+        self.assertIsNone(bg_accessor.Aggregator.from_carbon_name(""))
+
+
+class TestStage(unittest.TestCase):
+    # A lot is tested through TestRetention
+
+    def test_operators(self):
+        # Doesn't use assertEqual to make == and != are called
+        s1 = bg_accessor.Stage(points=24, precision=3600)
+        self.assertTrue(s1 != object())
+        self.assertFalse(s1 == object())
+
+        s2 = bg_accessor.Stage.from_string("24*3600s")
+        self.assertTrue(s1 == s2)
+        self.assertFalse(s1 != s2)
+
+        s3 = bg_accessor.Stage.from_string("12*3600s")
+        self.assertFalse(s1 == s3)
+        self.assertTrue(s1 != s3)
+
+
+class TestRetention(unittest.TestCase):
+
+    _TEST_STRING = "60*60s:24*3600s"
+    _TEST = bg_accessor.Retention.from_string(_TEST_STRING)
+
+    def test_simple(self):
+        for i, points, precision in ((0, 60, 60), (1, 24, 3600)):
+            self.assertEqual(precision, self._TEST.stages[i].precision)
+            self.assertEqual(points, self._TEST.stages[i].points)
+        self.assertEqual(self._TEST_STRING, self._TEST.as_string)
+
+    def test_empty(self):
+        r = bg_accessor.Retention.from_string("")
+        self.assertEqual((), r.stages)
+
+    def test_operators(self):
+        # Doesn't use assertEqual to make == and != are called
+        r1 = self._TEST
+        self.assertFalse(r1 == object())
+        self.assertTrue(r1 != object())
+
+        r2 = bg_accessor.Retention.from_string(self._TEST_STRING)
+        self.assertFalse(r1 != r2)
+        self.assertTrue(r1 == r2)
+
+        r3 = bg_accessor.Retention.from_string("")
+        self.assertFalse(r1 == r3)
+
+        r4 = bg_accessor.Retention.from_string(self._TEST_STRING + ":2*86400s")
+        self.assertFalse(r1 == r4)
+
+    def test_invalid(self):
+        strings = [
+            "60*60s:1*1234s",  # 1234 not multiple of 60
+            "60*1s:15*2s",  # 60*1>15*2
+        ]
+        for s in strings:
+            self.assertRaises(bg_accessor.InvalidArgumentError,
+                              bg_accessor.Retention.from_string, s)
 
 
 class TestMetricMetadata(unittest.TestCase):
 
-    _PRECISION = 60  # Period of the most precise retention policy.
-    _RETENTIONS = [(_PRECISION, 24*3600/_PRECISION)]
-
-    def _make_metric_metadata(self, **kwargs):
-        """Like bg_accessor.MetricMetadata but with different default values."""
-        kwargs.setdefault("carbon_retentions", self._RETENTIONS)
-        return bg_accessor.MetricMetadata(**kwargs)
-
-    def test_carbon_aggregations(self):
-        points = [0, 1, 2, 3]
-        points_duration = len(points) * self._PRECISION
-        expectations = (
-            ('average', 1.5),
-            ('last', 0),  # Points from most recent to oldest
-            ('min', 0),
-            ('max', 3),
-            ('sum', 6),
-        )
-        for aggregation, value in expectations:
-            m = self._make_metric_metadata(carbon_aggregation=aggregation)
-            aggregate = m.carbon_aggregate_points(time_span=points_duration, points=points)
-            self.assertEqual(value, aggregate)
-
-        m = self._make_metric_metadata(carbon_aggregation="does not exist")
-        self.assertRaises(bg_accessor.InvalidArgumentError,
-                          m.carbon_aggregate_points, time_span=points_duration, points=points)
-
-    def test_carbon_aggregations_no_points(self):
-        m = self._make_metric_metadata()
-        self.assertIsNone(m.carbon_aggregate_points(time_span=1.0, points=[]))
-
-    def test_carbon_xfilesfactor(self):
-        points = range(10)
-        points_duration = len(points) * self._PRECISION
-
-        m_explicit = self._make_metric_metadata(carbon_xfilesfactor=0.3)
-        self.assertFalse(m_explicit.carbon_aggregate_points(points_duration, points=points[:2]))
-        self.assertTrue(m_explicit.carbon_aggregate_points(points_duration, points=points[:3]))
-
-        m_default = bg_accessor.MetricMetadata()
-        self.assertEqual(0.5, m_default.carbon_xfilesfactor)
-
     def test_setattr(self):
-        m = self._make_metric_metadata()
+        m = bg_test_utils.make_metric("test")
         self.assertTrue(hasattr(m, "carbon_xfilesfactor"))
         self.assertRaises(AttributeError, setattr, m, "carbon_xfilesfactor", 0.5)
 

--- a/tests/test_cassandra.py
+++ b/tests/test_cassandra.py
@@ -18,6 +18,7 @@ import unittest
 
 import statistics
 
+from biggraphite import accessor as bg_accessor
 from biggraphite import test_utils as bg_test_utils
 
 _METRIC = bg_test_utils.make_metric("test.metric")
@@ -134,8 +135,8 @@ class TestAccessorWithCassandra(bg_test_utils.TestCaseWithAccessor):
 
     def test_create_metrics(self):
         meta_dict = {
-            "carbon_aggregation": "last",
-            "carbon_retentions": [[1, 60], [60, 3600]],
+            "aggregator": bg_accessor.Aggregator.last,
+            "retention": bg_accessor.Retention.from_string("60*1s:60*60s"),
             "carbon_xfilesfactor": 0.3,
         }
         metric = bg_test_utils.make_metric("a.b.c.d.e.f", **meta_dict)

--- a/tests/test_import_whisper.py
+++ b/tests/test_import_whisper.py
@@ -70,9 +70,9 @@ class TestMain(bg_test_utils.TestCaseWithFakeAccessor):
         metric = self.accessor.get_metric(metric)
         self.assertTrue(metric)
         self.assertEqual(metric.name, metric.name)
-        self.assertEqual(metric.carbon_aggregation, aggregation_method)
+        self.assertEqual(metric.aggregator.carbon_name, aggregation_method)
         self.assertEqual(metric.carbon_xfilesfactor, xfilesfactor)
-        self.assertEqual(metric.carbon_retentions, retentions)
+        self.assertEqual(metric.retention.as_string, "10*1s:10*2s")
 
         points_again = list(self.accessor.fetch_points(metric, time_from, time_to, step=1))
         self.assertEqual(points[-high_precision_duration:], points_again)


### PR DESCRIPTION
Aggregator used to be a string named carbon_aggregation, and retention a list of (point, precision).
This API-only change makes it easier to do server-side aggregation.
It also removes the support for xfilesfactor which we don't use and won't support with server-side aggregation at first (we still store it though)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/biggraphite/38)
<!-- Reviewable:end -->
