### PR TITLE
Force install of progressbar2>=3.9.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cassandra-driver
 enum34
 lmdb
-progressbar2
+progressbar2==3.9.3
 sortedcontainers
 statistics
 whisper


### PR DESCRIPTION
With earlier versions we would get the following error:

    File "/home/travis/build/criteo/biggraphite/.tox/pypy-coverage/site-packages/progressbar/bar.py", line 108, in update
          if self.redirect_stderr and sys.stderr.tell():
    IOError: [Errno 29] Illegal seek: '<stderr>'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/biggraphite/42)
<!-- Reviewable:end -->
