### PR TITLE
plugins: create cache and accessor lazilly

### DIFF
--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -224,7 +224,7 @@ class _LazyPreparedStatements(object):
             " ORDER BY offset;"
         ) % {"table": self._get_table_name(stage)}
         statement = self._session.prepare(statement_str)
-        statement.consistency_level = cassandra.ConsistencyLevel.LOCAL_ONE
+        statement.consistency_level = cassandra.ConsistencyLevel.ONE
         self.__stage_to_select[stage] = statement
         return statement, args
 

--- a/tests/test_carbon.py
+++ b/tests/test_carbon.py
@@ -46,8 +46,9 @@ class TestCarbonDatabase(bg_test_utils.TestCaseWithFakeAccessor):
         )
 
     def test_empty_settings(self):
+        database = bg_carbon.BigGraphiteDatabase(carbon_conf.Settings())
         self.assertRaises(carbon_exceptions.CarbonConfigException,
-                          bg_carbon.BigGraphiteDatabase, carbon_conf.Settings())
+                          database.cache)
 
     def test_get_fs_path(self):
         path = self._plugin.getFilesystemPath(_TEST_METRIC)

--- a/tests/test_metadata_cache.py
+++ b/tests/test_metadata_cache.py
@@ -50,9 +50,15 @@ class TestGraphiteUtilsInternals(bg_test_utils.TestCaseWithFakeAccessor):
 
     def test_instance_cache(self):
         """Check that we do cache JSON instances."""
+        name = _TEST_METRIC.name
+        self.assertEquals(self.metadata_cache.has_metric(name), False)
+        self.assertEquals(self.metadata_cache.get_metric(name), None)
+
         self.metadata_cache.create_metric(_TEST_METRIC)
-        first = self.metadata_cache.get_metric(_TEST_METRIC.name)
-        second = self.metadata_cache.get_metric(_TEST_METRIC.name)
+        self.assertEquals(self.metadata_cache.has_metric(name), True)
+
+        first = self.metadata_cache.get_metric(name)
+        second = self.metadata_cache.get_metric(name)
         self.assertIs(first.metadata, second.metadata)
 
     def test_unicode(self):


### PR DESCRIPTION
No need to create them before we use them. This will also prevent
creating the cache as root before we start using it as 'graphite'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/biggraphite/84)
<!-- Reviewable:end -->
