### PR TITLE
Add bgutil repair and repair() functions

### DIFF
--- a/biggraphite/accessor.py
+++ b/biggraphite/accessor.py
@@ -620,6 +620,11 @@ class Accessor(object):
                     time_end, stage.as_string))
 
     @abc.abstractmethod
+    def has_metric(self, metric_name):
+        """Return a True if this metric exists, else return False."""
+        self._check_connected()
+
+    @abc.abstractmethod
     def get_metric(self, metric_name):
         """Return a MetricMetadata for this metric_name, None if no such metric."""
         self._check_connected()
@@ -679,6 +684,14 @@ class Accessor(object):
         """
         if not isinstance(metric, Metric):
             raise InvalidArgumentError("%s is not a Metric instance" % metric)
+        self._check_connected()
+
+    @abc.abstractmethod
+    def repair(self):
+        """Repair potential corruptions in the database.
+
+        This operation can potentially be very slow.
+        """
         self._check_connected()
 
     @abc.abstractmethod

--- a/biggraphite/cli/bgutil.py
+++ b/biggraphite/cli/bgutil.py
@@ -23,12 +23,14 @@ from biggraphite import utils as bg_utils
 
 from biggraphite.cli import command_test
 from biggraphite.cli import command_read
+from biggraphite.cli import command_repair
 from biggraphite.cli import command_shell
 
 
 COMMANDS = [
     command_test.CommandTest(),
     command_read.CommandRead(),
+    command_repair.CommandRepair(),
     command_shell.CommandShell(),
 ]
 

--- a/biggraphite/cli/command_repair.py
+++ b/biggraphite/cli/command_repair.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# Copyright 2016 Criteo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Repair Command."""
+
+
+import logging
+
+from biggraphite.cli import command
+from biggraphite import metadata_cache
+
+
+class CommandRepair(command.BaseCommand):
+    """Check that you can use BigGraphite."""
+
+    NAME = "repair"
+    HELP = "Run some repairs."
+
+    def run(self, accessor, opts):
+        """Run some repairs.
+
+        See command.BaseCommand
+        """
+        accessor.connect()
+
+        if opts.storage_path:
+            cache = metadata_cache.DiskCache(accessor, opts.storage_path)
+            # TODO: Once repair() has support for start_key and end_key it will be
+            # easier to parallelise this command.
+            cache.open()
+            cache.repair()
+        else:
+            logging.warning(
+                'Skipping disk cache repair because storage_path is empty')
+
+        accessor.repair()

--- a/biggraphite/cli/command_test.py
+++ b/biggraphite/cli/command_test.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# Copyright 2016 Criteo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test Command."""
+
+from biggraphite.cli import command
+
+
+class CommandTest(command.BaseCommand):
+    """Check that you can use BigGraphite."""
+
+    NAME = "test"
+    HELP = "Run some tests."
+
+    def run(self, accessor, opts):
+        """Run some tests.
+
+        See command.BaseCommand
+        """
+        accessor.connect()

--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -309,22 +309,12 @@ class _CassandraAccessor(bg_accessor.Accessor):
         components = self._components_from_name(metric.name)
         queries = []
 
-        # Check if parent dir exists. This is one round-trip but worthwile since otherwise
-        # creating each parent directory requires a round-trip and the vast majority of
-        # metrics have siblings.
+        # Check if parent dir exists. This is one round-trip but worthwile since
+        # otherwise creating each parent directory requires a round-trip and the
+        # vast majority of metrics have siblings.
         parent_dir = metric.name.rpartition(".")[0]
         if parent_dir and not self.glob_directory_names(parent_dir):
-            # Create parent directories
-            directory_path = []
-            for component in components[:-2]:  # -1 for _LAST_COMPONENT, -1 for metric
-                directory_path.append(component)
-                directory_name = ".".join(directory_path)
-                directory_components = directory_path + [_LAST_COMPONENT]
-                directory_padding = [None] * (_COMPONENTS_MAX_LEN - len(directory_components))
-                queries.append((
-                    self.__insert_directories_statement,
-                    [directory_name] + directory_components + directory_padding,
-                ))
+            queries.extend(self._create_parent_dirs_queries(components))
 
         # Finally, create the metric
         padding = [None] * (_COMPONENTS_MAX_LEN - len(components))
@@ -341,6 +331,20 @@ class _CassandraAccessor(bg_accessor.Accessor):
         # We can still end up with empty directories, which will need a reaper job to clean them.
         for statement, args in queries:
             self.__session.execute(statement, args)
+
+    def _create_parent_dirs_queries(self, components):
+        queries = []
+        directory_path = []
+        for component in components[:-2]:  # -1 for _LAST_COMPONENT, -1 for metric
+            directory_path.append(component)
+            directory_name = ".".join(directory_path)
+            directory_components = directory_path + [_LAST_COMPONENT]
+            directory_padding = [None] * (_COMPONENTS_MAX_LEN - len(directory_components))
+            queries.append((
+                self.__insert_directories_statement,
+                [directory_name] + directory_components + directory_padding,
+            ))
+        return queries
 
     @staticmethod
     def _components_from_name(metric_name):
@@ -406,6 +410,24 @@ class _CassandraAccessor(bg_accessor.Accessor):
             res.append(select)
 
         return res
+
+    def has_metric(self, metric_name):
+        """See bg_accessor.Accessor."""
+        super(_CassandraAccessor, self).has_metric(metric_name)
+        encoded_metric_name = bg_accessor.encode_metric_name(metric_name)
+        result = list(self.__session.execute(
+            self.__select_metric_statement, (encoded_metric_name, )))
+        if not result:
+            return False
+
+        # Small trick here: we also check that the parent directory
+        # exists because that's what we check to create the directory
+        # hierarchy.
+        parent_dir = metric_name.rpartition(".")[0]
+        if parent_dir and not self.glob_directory_names(parent_dir):
+            return False
+
+        return True
 
     def get_metric(self, metric_name):
         """See bg_accessor.Accessor."""
@@ -500,6 +522,27 @@ class _CassandraAccessor(bg_accessor.Accessor):
                     count_down.on_cassandra_failure,
                 )
 
+    def repair(self):
+        """See bg_accessor.Accessor."""
+        # Step 1: Create missing parent directories.
+        statement_str = (
+            "SELECT name FROM \"%s\".directories WHERE component_0 = 'carbon' ALLOW FILTERING;" %
+            self.keyspace_metadata)
+        statement = self.__session.prepare(statement_str)
+        statement.consistency_level = cassandra.ConsistencyLevel.QUORUM
+        statement.retry_policy = cassandra.policies.DowngradingConsistencyRetryPolicy
+        statement.request_timeout = 60
+        result = self.__session.execute(statement)
+
+        for row in result:
+            parent_dir = row.name.rpartition(".")[0]
+            if parent_dir and not self.glob_directory_names(parent_dir):
+                logging.warning("Creating missing parent dir '%s'" % parent_dir)
+                components = self._components_from_name(row.name)
+                queries = self._create_parent_dirs_queries(components)
+                for statement, args in queries:
+                    self.__session.execute(statement, args)
+
     def shutdown(self):
         """See bg_accessor.Accessor."""
         super(_CassandraAccessor, self).shutdown()
@@ -514,7 +557,10 @@ class _CassandraAccessor(bg_accessor.Accessor):
     def _upgrade_schema(self):
         # Currently no change, so only upgrade operation is to setup
         try:
-            self.__session.execute("SELECT name FROM directories LIMIT 1;")
+            self.__session.execute(
+                "SELECT name FROM \"%s\".directories LIMIT 1;" %
+                self.keyspace_metadata
+            )
             return  # Already up to date.
         except Exception:
             pass

--- a/biggraphite/drivers/memory.py
+++ b/biggraphite/drivers/memory.py
@@ -55,6 +55,10 @@ class _MemoryAccessor(bg_accessor.Accessor):
         super(_MemoryAccessor, self).shutdown(*args, **kwargs)
         self.is_connected = False
 
+    def repair(self, *args, **kwargs):
+        """See the real Accessor for a description."""
+        pass
+
     def insert_points_async(self, metric, datapoints, on_done=None):
         """See the real Accessor for a description."""
         super(_MemoryAccessor, self).insert_points_async(
@@ -113,6 +117,11 @@ class _MemoryAccessor(bg_accessor.Accessor):
         """See the real Accessor for a description."""
         super(_MemoryAccessor, self).glob_directory_names(glob)
         return self.__glob_names(self._directory_names, glob)
+
+    def has_metric(self, metric_name):
+        """See bg_accessor.Accessor."""
+        super(_MemoryAccessor, self).has_metric(metric_name)
+        return self.get_metric(metric_name) is not None
 
     def get_metric(self, metric_name):
         """See the real Accessor for a description."""

--- a/biggraphite/utils.py
+++ b/biggraphite/utils.py
@@ -162,6 +162,8 @@ def add_argparse_arguments(parser):
     parser.add_argument("--cassandra_timeout", metavar="TIMEOUT", type=int,
                         help="Cassandra query timeout in seconds.",
                         default=DEFAULT_CASSANDRA_TIMEOUT)
+    parser.add_argument("--storage_path", metavar="PATH",
+                        help="Storage path (cache, etc..)")
 
 
 def settings_from_args(args):

--- a/tests/test_cassandra.py
+++ b/tests/test_cassandra.py
@@ -131,7 +131,9 @@ class TestAccessorWithCassandra(bg_test_utils.TestCaseWithAccessor):
         }
         metric = bg_test_utils.make_metric("a.b.c.d.e.f", **meta_dict)
 
+        self.assertEquals(self.accessor.has_metric(metric.name), False)
         self.accessor.create_metric(metric)
+        self.assertEquals(self.accessor.has_metric(metric.name), True)
         metric_again = self.accessor.get_metric(metric.name)
         self.assertEqual(metric.name, metric_again.name)
         for k, v in meta_dict.iteritems():

--- a/tests/test_metadata_cache.py
+++ b/tests/test_metadata_cache.py
@@ -67,6 +67,29 @@ class TestGraphiteUtilsInternals(bg_test_utils.TestCaseWithFakeAccessor):
         self.metadata_cache.create_metric(metric)
         self.metadata_cache.get_metric(metric_name)
 
+    def test_repair(self):
+        # Add a normal metric.
+        metric_name = "a.b.test"
+        metric = bg_test_utils.make_metric(metric_name)
+
+        self.metadata_cache.create_metric(metric)
+        self.metadata_cache.repair()
+        self.metadata_cache.get_metric(metric_name)
+        # Should be only one entry, and it was a hit.
+        self.assertEquals(self.metadata_cache.hit_count, 1)
+        self.assertEquals(self.metadata_cache.miss_count, 0)
+
+        # Add a spurious metric.
+        metric_name = "a.b.fake"
+        metric = bg_test_utils.make_metric(metric_name)
+
+        self.metadata_cache._cache(metric_name, metric.metadata)
+        self.metadata_cache.repair()
+        self.metadata_cache.get_metric(metric_name)
+        # repair() will remove it, and the get will produce a miss.
+        self.assertEquals(self.metadata_cache.hit_count, 1)
+        self.assertEquals(self.metadata_cache.miss_count, 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Currently very slow, probably even too slow to be usable
on an actual setup. We need a way to parallelize that.

Also make some changes in create() and exists(): exists() will
check if the parent directory exists too, this allows fsck
to ignore metrics and run only on directories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/biggraphite/99)
<!-- Reviewable:end -->
