### PR TITLE
cassandra: add support for TimeWindowCompactionStrategy and tweak DTCS

### DIFF
--- a/biggraphite/accessor.py
+++ b/biggraphite/accessor.py
@@ -445,7 +445,7 @@ class MetricMetadata(object):
     )
 
     _DEFAULT_AGGREGATOR = Aggregator.average
-    _DEFAULT_RETENTION = Retention.from_string("86400*1s:2000*60s")
+    _DEFAULT_RETENTION = Retention.from_string("86400*1s:10080*60s")
     _DEFAULT_XFILESFACTOR = 0.5
 
     def __init__(self, aggregator=None, retention=None, carbon_xfilesfactor=None):


### PR DESCRIPTION
- TWCS is a new compaction strategy that replaces DTCS in >3.8
- Change _EXPECTED_POINTS_PER_READ to 2000 to make sure that reading
  a day of date reads only one sstable.
- Change _MIN_ROW_SIZE_MS to 6 hours to make sure that we have too
  many queries to do when reading points.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/biggraphite/100)
<!-- Reviewable:end -->
