### PR TITLE
Use ONE instead of ANY for write consistency

### DIFF
--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -207,7 +207,7 @@ class _LazyPreparedStatements(object):
             " VALUES (?, ?, ?, ?, ?);"
         ) % {"table": self._get_table_name(stage)}
         statement = self._session.prepare(statement_str)
-        statement.consistency_level = cassandra.ConsistencyLevel.ANY
+        statement.consistency_level = cassandra.ConsistencyLevel.ONE
         self.__stage_to_insert[stage] = statement
         return statement, args
 


### PR DESCRIPTION
I did not see any comments or documentation suggesting there is a rationale
behind the use of ANY, and thus believe this is a potential bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/biggraphite/102)
<!-- Reviewable:end -->
