### PR TITLE
cassandra: add a way to disable compression

### DIFF
--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -244,8 +244,8 @@ class _CassandraAccessor(bg_accessor.Accessor):
 
     _DEFAULT_CASSANDRA_PORT = 9042
 
-    def __init__(self, keyspace='biggraphite', contact_points=[],
-                 port=None, concurrency=4, default_timeout=None):
+    def __init__(self, keyspace='biggraphite', contact_points=[], port=None,
+                 concurrency=4, default_timeout=None, compression=False):
         """Record parameters needed to connect.
 
         Args:
@@ -253,6 +253,8 @@ class _CassandraAccessor(bg_accessor.Accessor):
           contact_points: list of strings, the hostnames or IP to use to discover Cassandra.
           port: The port to connect to, as an int.
           concurrency: How many worker threads to use.
+          default_timeout: Default timeout for operations in seconds.
+          compression: One of False, True, "lz4", "snappy"
         """
         backend_name = "cassandra:" + keyspace
         super(_CassandraAccessor, self).__init__(backend_name)
@@ -261,6 +263,7 @@ class _CassandraAccessor(bg_accessor.Accessor):
         self.contact_points = contact_points
         self.port = port or self._DEFAULT_CASSANDRA_PORT
         self.__concurrency = concurrency
+        self.__compression = compression
         self.__downsampler = _downsampling.Downsampler()
         self.__cluster = None  # setup by connect()
         self.__lazy_statements = None  # setup by connect()
@@ -275,6 +278,7 @@ class _CassandraAccessor(bg_accessor.Accessor):
         self.__cluster = c_cluster.Cluster(
             self.contact_points, self.port,
             executor_threads=self.__concurrency,
+            compression=self.__compression,
         )
         self.__cluster.connection_class = _CappedConnection  # Limits in flight requests
         self.__cluster.row_factory = c_query.tuple_factory  # Saves 2% CPU

--- a/biggraphite/utils.py
+++ b/biggraphite/utils.py
@@ -27,6 +27,7 @@ DEFAULT_CASSANDRA_CONTACT_POINTS = "127.0.0.1"
 DEFAULT_CASSANDRA_PORT = 9042
 DEFAULT_CASSANDRA_TIMEOUT = 10.0
 DEFAULT_CASSANDRA_CONNECTIONS = 4
+DEFAULT_CASSANDRA_COMPRESSION = False
 
 
 class Error(Exception):
@@ -90,12 +91,24 @@ def cassandra_accessor_from_settings(settings):
     Returns:
       Cassandra accessor (not connected)
     """
+    def _compression_values(value):
+        # value is either a bool or a str.
+        if value == 'True':
+            return value
+        elif value == 'False':
+            return value
+        elif type(value) is bool:
+            return value
+        else:
+            return str(value)
+
     options = (
         ("keyspace", "BG_CASSANDRA_KEYSPACE", str, True),
         ("contact_points", "BG_CASSANDRA_CONTACT_POINTS", list_from_str, False),
         ("port", "BG_CASSANDRA_PORT", int, True),
         ("concurrency", "BG_CASSANDRA_CONNECTIONS", int, True),
         ("default_timeout", "BG_CASSANDRA_TIMEOUT", int, True),
+        ("compression", "BG_CASSANDRA_COMPRESSION", _compression_values, True),
     )
     kwargs = {}
     for name, up_name, func, optional in options:
@@ -162,6 +175,9 @@ def add_argparse_arguments(parser):
     parser.add_argument("--cassandra_timeout", metavar="TIMEOUT", type=int,
                         help="Cassandra query timeout in seconds.",
                         default=DEFAULT_CASSANDRA_TIMEOUT)
+    parser.add_argument("--cassandra_compression", metavar="COMPRESSION", type=str,
+                        help="Cassandra network compression.",
+                        default=DEFAULT_CASSANDRA_COMPRESSION)
     parser.add_argument("--storage_path", metavar="PATH",
                         help="Storage path (cache, etc..)")
 
@@ -182,6 +198,7 @@ def settings_from_args(args):
         'BG_CASSANDRA_PORT': args.cassandra_port,
         'BG_CASSANDRA_CONNECTIONS': args.cassandra_connections,
         'BG_CASSANDRA_TIMEOUT': args.cassandra_timeout,
+        'BG_CASSANDRA_COMPRESSION': args.cassandra_compression,
     }
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,6 +62,12 @@ class TestGraphiteUtilsInternals(unittest.TestCase):
     def test_cassandra_accessor(self):
         settings = {'BG_DRIVER': 'cassandra'}
         settings["BG_CASSANDRA_CONTACT_POINTS"] = "localhost"
+        settings["BG_CASSANDRA_COMPRESSION"] = True
+        settings["BG_CASSANDRA_TIMEOUT"] = 5
+        accessor = bg_utils.accessor_from_settings(settings)
+        self.assertNotEquals(accessor, None)
+
+        settings["BG_CASSANDRA_COMPRESSION"] = False
         accessor = bg_utils.accessor_from_settings(settings)
         self.assertNotEquals(accessor, None)
 


### PR DESCRIPTION
We write mostly individual datapoints so we really don't need compression.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/biggraphite/103)
<!-- Reviewable:end -->
