### PR TITLE
graphite: don't remove metadata_cache when refreshing metric

### DIFF
--- a/biggraphite/metadata_cache.py
+++ b/biggraphite/metadata_cache.py
@@ -64,6 +64,9 @@ class DiskCache(object):
 
     def __init__(self, accessor, path):
         """Create a new DiskCache."""
+        assert accessor
+        assert path
+
         self.hit_count = 0
         self.miss_count = 0
         self.__accessor_lock = threading.Lock()

--- a/biggraphite/plugins/graphite.py
+++ b/biggraphite/plugins/graphite.py
@@ -41,6 +41,9 @@ class Reader(object):
 
     def __init__(self, accessor, metadata_cache, metric_name):
         """Create a new reader."""
+        assert accessor
+        assert metadata_cache
+
         self._accessor = accessor
         self._metadata_cache = metadata_cache
         self._metric = None
@@ -68,7 +71,6 @@ class Reader(object):
     def __refresh_metric(self):
         if self._metric is None:
             self._metric = self._metadata_cache.get_metric(self._metric_name)
-            self._metadata_cache = None
 
     def fetch(self, start_time, end_time, now=None):
         """Fetch point for a given interval as per the Graphite API.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,3 @@ whisper
 
 git+https://github.com/graphite-project/carbon.git@master#egg=carbon
 git+https://github.com/graphite-project/graphite-web.git@master#egg=graphite-web
-


### PR DESCRIPTION
This should fix #135. I have no idea why this code was here
in the first place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/biggraphite/136)
<!-- Reviewable:end -->
