### PR TITLE
accessor: do not create empty directories for double-dots

### DIFF
--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -578,6 +578,8 @@ class _CassandraAccessor(bg_accessor.Accessor):
 
     def make_metric(self, name, metadata):
         """See bg_accessor.Accessor."""
+        # Cleanup name (avoid double dots)
+        name = ".".join(self._components_from_name(name)[:-1])
         encoded_name = bg_accessor.encode_metric_name(name)
         id = uuid.uuid5(self._UUID_NAMESPACE, encoded_name)
         return bg_accessor.Metric(name, id, metadata)
@@ -633,7 +635,7 @@ class _CassandraAccessor(bg_accessor.Accessor):
     def _components_from_name(metric_name):
         res = metric_name.split(".")
         res.append(_LAST_COMPONENT)
-        return res
+        return filter(None, res)
 
     def drop_all_metrics(self):
         """See bg_accessor.Accessor."""

--- a/biggraphite/test_utils.py
+++ b/biggraphite/test_utils.py
@@ -116,10 +116,9 @@ def prepare_graphite_imports():
 _UUID_NAMESPACE = uuid.UUID('{00000000-0000-0000-0000-000000000000}')
 
 
-def make_metric(name, metadata=None, **kwargs):
+def make_metric(name, metadata=None, accessor=None, **kwargs):
     """Create a bg_accessor.Metric with specified metadata."""
     encoded_name = bg_accessor.encode_metric_name(name)
-    id = uuid.uuid5(_UUID_NAMESPACE, encoded_name)
     retention = kwargs.get("retention")
     if isinstance(retention, basestring):
         kwargs["retention"] = bg_accessor.Retention.from_string(retention)
@@ -128,7 +127,11 @@ def make_metric(name, metadata=None, **kwargs):
         assert not kwargs
     else:
         metadata = bg_accessor.MetricMetadata(**kwargs)
-    return bg_accessor.Metric(name, id, metadata)
+    if not accessor:
+        uid = uuid.uuid5(_UUID_NAMESPACE, encoded_name)
+        return bg_accessor.Metric(name, uid, metadata)
+    else:
+        return accessor.make_metric(name, metadata)
 
 
 class TestCaseWithTempDir(unittest.TestCase):
@@ -163,6 +166,10 @@ class TestCaseWithFakeAccessor(TestCaseWithTempDir):
                              return_value=self.accessor)
         patcher.start()
         self.addCleanup(patcher.stop)
+
+    def make_metric(self, name, metadata=None, **kwargs):
+        """Create a bg_accessor.Metric with specified metadata."""
+        return make_metric(name, metadata=metadata, accessor=self.accessor, **kwargs)
 
 
 @unittest.skipUnless(
@@ -232,6 +239,10 @@ class TestCaseWithAccessor(TestCaseWithTempDir):
     def _reset_keyspace(cls, session, keyspace):
         drop_keyspace(session, keyspace)
         create_unreplicated_keyspace(session, keyspace)
+
+    def make_metric(self, name, metadata=None, **kwargs):
+        """Create a bg_accessor.Metric with specified metadata."""
+        return make_metric(name, metadata=metadata, accessor=self.accessor, **kwargs)
 
     def __drop_all_metrics(self):
         self.accessor.connect()

--- a/tests/test_carbon.py
+++ b/tests/test_carbon.py
@@ -94,6 +94,17 @@ class TestCarbonDatabase(bg_test_utils.TestCaseWithFakeAccessor):
         actual_points = self.accessor.fetch_points(metric, 1, 2, stage=metric.retention[0])
         self.assertEqual(points, list(actual_points))
 
+    def test_write_doubledots(self):
+        metric = self.make_metric("a.b..c")
+        metric_1 = self.make_metric("a.b.c")
+        points = [(1, 42)]
+        self.accessor.create_metric(metric)
+        self._plugin.write(metric.name, points)
+        actual_points = self.accessor.fetch_points(metric, 1, 2, stage=metric.retention[0])
+        self.assertEqual(points, list(actual_points))
+        actual_points = self.accessor.fetch_points(metric_1, 1, 2, stage=metric.retention[0])
+        self.assertEqual(points, list(actual_points))
+
 
 class TestMultiDatabase(bg_test_utils.TestCaseWithFakeAccessor):
 

--- a/tests/test_cassandra.py
+++ b/tests/test_cassandra.py
@@ -232,6 +232,20 @@ class TestAccessorWithCassandra(bg_test_utils.TestCaseWithAccessor):
         # TODO(c.chary): Add better test for repair()
         self.accessor.repair()
 
+    def test_doubledots(self):
+        metric = self.make_metric("a.b..c")
+        metric_1 = self.make_metric("a.b.c")
+        points = [(1, 42)]
+        self.accessor.create_metric(metric)
+        self.accessor.create_metric(metric_1)
+        self.assertEqual(['a.b.c'], self.accessor.glob_metric_names("a.b.*"))
+
+        self.accessor.insert_points(metric, points)
+        actual_points = self.accessor.fetch_points(metric, 1, 2, stage=metric.retention[0])
+        self.assertEqual(points, list(actual_points))
+        actual_points = self.accessor.fetch_points(metric_1, 1, 2, stage=metric.retention[0])
+        self.assertEqual(points, list(actual_points))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Double dots ('..') has the same meaning as '//' in a filesystem
so we should not create empty directories in this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/biggraphite/139)
<!-- Reviewable:end -->
