### PR TITLE
Automatic stage selection from metric timestamp for bgutil read

### DIFF
--- a/biggraphite/accessor.py
+++ b/biggraphite/accessor.py
@@ -447,6 +447,23 @@ class Retention(object):
         # There is always at least one stage.
         return self.stages[-1]
 
+    def align_time_window(self, start_time, end_time, now):
+        """Constrain the provided range in an aligned interval within retention."""
+        stage = self.find_stage_for_ts(searched=start_time, now=now)
+
+        now = stage.round_up(now)
+
+        oldest_timestamp = now - stage.duration
+        start_time = max(start_time, oldest_timestamp)
+        start_time = stage.round_down(start_time)
+
+        end_time = min(now, end_time)
+        end_time = stage.round_up(end_time)
+
+        if end_time < start_time:
+            end_time = start_time
+        return start_time, end_time, stage
+
     @property
     def points(self):
         """Return the total number of points for this retention."""

--- a/biggraphite/cli/command_read.py
+++ b/biggraphite/cli/command_read.py
@@ -95,11 +95,14 @@ class CommandRead(command.BaseCommand):
             print("Metric '%s' doesn't exist" % metric_name)
             return
 
-        # TODO(c.chary): get a stage that matches the time window.
-        stage = forced_stage or metric.metadata.retention[0]
-
-        time_start = stage.round_up(time.mktime(time_start.timetuple()))
-        time_stop = stage.round_up(time.mktime(time_end.timetuple()))
+        if forced_stage:
+            stage = forced_stage
+            time_start = stage.round_up(time.mktime(time_start.timetuple()))
+            time_stop = stage.round_up(time.mktime(time_end.timetuple()))
+        else:
+            time_start, time_end, stage = metric.retention.align_time_window(
+                time_start, time_end, time.time()
+            )
 
         print("Name: ", metric.name)
         print("Time window: %s to %s" % (time_start, time_stop))

--- a/biggraphite/plugins/graphite.py
+++ b/biggraphite/plugins/graphite.py
@@ -51,22 +51,12 @@ class Reader(object):
 
     def __get_time_info(self, start_time, end_time, now):
         """Constrain the provided range in an aligned interval within retention."""
-        stage = bg_accessor.Stage(precision=1, points=60)
         if self._metric and self._metric.retention:
-            stage = self._metric.retention.find_stage_for_ts(searched=start_time, now=now)
+            retention = self._metric.retention
+        else:
+            retention = bg_accessor.Retention.from_string("1*60s")
 
-        now = stage.round_up(now)
-
-        oldest_timestamp = now - stage.duration
-        start_time = max(start_time, oldest_timestamp)
-        start_time = stage.round_down(start_time)
-
-        end_time = min(now, end_time)
-        end_time = stage.round_up(end_time)
-
-        if end_time < start_time:
-            end_time = start_time
-        return start_time, end_time, stage
+        return retention.align_time_window(start_time, end_time, now)
 
     def __refresh_metric(self):
         if self._metric is None:

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -145,6 +145,30 @@ class TestRetention(unittest.TestCase):
             self.assertRaises(bg_accessor.InvalidArgumentError,
                               bg_accessor.Retention.from_string, s)
 
+    def test_align_time_window(self):
+        retention = self._TEST
+
+        self.assertEqual(
+            retention.align_time_window(0, 0, 0),
+            (0, 0, bg_accessor.Stage(precision=60, points=60))
+        )
+        self.assertEqual(
+            retention.align_time_window(60, 120, 1200),
+            (60, 120, bg_accessor.Stage(precision=60, points=60))
+        )
+        self.assertEqual(
+            retention.align_time_window(61, 119, 1200),
+            (60, 120, bg_accessor.Stage(precision=60, points=60))
+        )
+        self.assertEqual(
+            retention.align_time_window(59, 121, 1200),
+            (0, 180, bg_accessor.Stage(precision=60, points=60))
+        )
+        self.assertEqual(
+            retention.align_time_window(59, 3601, 8000),
+            (0, 7200, bg_accessor.Stage(precision=3600, points=24))
+        )
+
 
 class TestMetricMetadata(unittest.TestCase):
 


### PR DESCRIPTION
This PR should also save one fallback object creation request for the graphite plugin.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/biggraphite/153)
<!-- Reviewable:end -->
