### PR TITLE
cassandra: read path optimizations

### DIFF
--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -507,8 +507,8 @@ class _CassandraAccessor(bg_accessor.Accessor):
             metrics_enabled=True,
         )
         self.__cluster.connection_class = _CappedConnection  # Limits in flight requests
-        self.__cluster.row_factory = c_query.tuple_factory  # Saves 2% CPU
         self.__session = self.__cluster.connect()
+        self.__session.row_factory = c_query.tuple_factory  # Saves 2% CPU
         if self.__timeout:
             self.__session.default_timeout = self.__timeout
         if not skip_schema_upgrade:
@@ -683,7 +683,8 @@ class _CassandraAccessor(bg_accessor.Accessor):
             results_generator=True,
         )
         return bg_accessor.PointGrouper(
-            metric, time_start_ms, time_end_ms, stage, query_results)
+            metric, time_start_ms, time_end_ms, stage, query_results
+        )
 
     def _fetch_points_make_selects(self, metric_id, time_start_ms,
                                    time_end_ms, stage):

--- a/biggraphite/graphite_utils.py
+++ b/biggraphite/graphite_utils.py
@@ -45,16 +45,15 @@ def accessor_from_settings(settings):
     return bg_utils.accessor_from_settings(settings)
 
 
-def storage_path(settings):
-    """Get storage path from configuration.
+def cache_from_settings(accessor, settings):
+    """Get Cache from Graphite-related configuration object.
 
     Args:
-      settings: either carbon_conf.Settings or a Django-like settings object
+      accessor: a connected Accessor.
+      settings: either carbon_conf.Settings or a Django-like settings object.
 
     Returns:
-      An absolute path.
+      Cache (not opened).
     """
-    path, found = bg_utils.get_setting(settings, "STORAGE_DIR")
-    if not path or not os_path.exists(path):
-        raise ConfigError("STORAGE_DIR is set to an unexisting directory: '%s'" % path)
-    return os_path.abspath(path)
+    settings = bg_utils.settings_from_confattr(settings)
+    return bg_utils.cache_from_settings(accessor, settings)

--- a/biggraphite/graphite_utils.py
+++ b/biggraphite/graphite_utils.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Graphite utility module."""
 
-from os import path as os_path
-
 from biggraphite import utils as bg_utils
 
 

--- a/biggraphite/plugins/carbon.py
+++ b/biggraphite/plugins/carbon.py
@@ -21,11 +21,9 @@ from __future__ import absolute_import  # Otherwise carbon is this module.
 # patch: https://goo.gl/1gAcz1 .
 # test-requirements.txt as a URL pinned at the correct version.
 from carbon import database
-from carbon import exceptions as carbon_exceptions
 
 from biggraphite import graphite_utils
 from biggraphite import accessor
-from biggraphite import metadata_cache
 
 # Ignore D102: Missing docstring in public method: Most of them come from upstream module.
 # pylama:ignore=D102

--- a/biggraphite/plugins/carbon.py
+++ b/biggraphite/plugins/carbon.py
@@ -63,12 +63,7 @@ class BigGraphiteDatabase(database.TimeSeriesDatabase):
 
     def cache(self):
         if not self._cache:
-            try:
-                storage_path = graphite_utils.storage_path(self._settings)
-            except graphite_utils.ConfigError as e:
-                raise carbon_exceptions.CarbonConfigException(e)
-
-            cache = metadata_cache.DiskCache(self.accessor(), storage_path)
+            cache = graphite_utils.cache_from_settings(self.accessor(), self._settings)
             cache.open()
             self._cache = cache
 
@@ -77,6 +72,7 @@ class BigGraphiteDatabase(database.TimeSeriesDatabase):
     def write(self, metric_name, datapoints):
         # Get a Metric object from metric name.
         metric = self.cache().get_metric(metric_name=metric_name)
+
         # Round down timestamp because inner functions expect integers.
         datapoints = [(int(timestamp), value) for timestamp, value in datapoints]
 

--- a/biggraphite/plugins/graphite.py
+++ b/biggraphite/plugins/graphite.py
@@ -26,7 +26,6 @@ from graphite.logger import log
 from biggraphite import accessor as bg_accessor
 from biggraphite import glob_utils
 from biggraphite import graphite_utils
-from biggraphite import metadata_cache as bg_metadata_cache
 
 
 _CONFIG_NAME = "biggraphite"
@@ -161,7 +160,7 @@ class Finder(object):
         if not self._cache:
             # TODO: Allow to use Django's cache.
             from django.conf import settings as django_settings
-            cache = graphite_utils.cache_from_settings(self.accessor(), storage_path)
+            cache = graphite_utils.cache_from_settings(self.accessor(), django_settings)
             cache.open()
             self._cache = cache
         return self._cache

--- a/biggraphite/plugins/graphite.py
+++ b/biggraphite/plugins/graphite.py
@@ -161,9 +161,9 @@ class Finder(object):
         if not self._cache:
             # TODO: Allow to use Django's cache.
             from django.conf import settings as django_settings
-            storage_path = graphite_utils.storage_path(django_settings)
-            self._cache = bg_metadata_cache.DiskCache(self.accessor(), storage_path)
-            self._cache.open()
+            cache = graphite_utils.cache_from_settings(self.accessor(), storage_path)
+            cache.open()
+            self._cache = cache
         return self._cache
 
     def find_nodes(self, query):

--- a/biggraphite/test_utils.py
+++ b/biggraphite/test_utils.py
@@ -149,6 +149,7 @@ class TestCaseWithFakeAccessor(TestCaseWithTempDir):
     """"A TestCase with a FakeAccessor."""
 
     KEYSPACE = "fake_keyspace"
+    CACHE_CLASS = bg_metadata_cache.MemoryCache
 
     def setUp(self):
         """Create a new Accessor in self.acessor."""
@@ -156,9 +157,8 @@ class TestCaseWithFakeAccessor(TestCaseWithTempDir):
         self.accessor = bg_memory.build()
         self.accessor.connect()
         self.addCleanup(self.accessor.shutdown)
-        self.metadata_cache = bg_metadata_cache.DiskCache(
-            self.accessor, self.tempdir)
-        self.metadata_cache.MAP_SIZE = 1024*1024
+        self.metadata_cache = self.CACHE_CLASS(
+            self.accessor, {'path': self.tempdir, 'size': 1024*1024})
         self.metadata_cache.open()
         self.addCleanup(self.metadata_cache.close)
 
@@ -181,6 +181,7 @@ class TestCaseWithAccessor(TestCaseWithTempDir):
     """"A TestCase with an Accessor for an ephemeral Cassandra cluster."""
 
     KEYSPACE = "testkeyspace"
+    CACHE_CLASS = bg_metadata_cache.MemoryCache
 
     @classmethod
     def setUpClass(cls):
@@ -233,8 +234,8 @@ class TestCaseWithAccessor(TestCaseWithTempDir):
         self.accessor.connect()
         self.addCleanup(self.accessor.shutdown)
         self.addCleanup(self.__drop_all_metrics)
-        self.metadata_cache = bg_metadata_cache.DiskCache(self.accessor, self.tempdir)
-        self.metadata_cache.MAP_SIZE = 1024*1024
+        self.metadata_cache = self.CACHE_CLASS(
+            self.accessor, {'path': self.tempdir, 'size': 1024*1024})
         self.metadata_cache.open()
         self.addCleanup(self.metadata_cache.close)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,25 @@
-ConfigArgParse
-cassandra-driver
-enum34
+
+# Commande line
 humanize
 ipython
-lmdb
 parsedatetime
 progressbar2
-scales
-sortedcontainers
-statistics
-whisper
 
+# Memory driver
+sortedcontainers
+
+# Cassandra driver
+cassandra-driver
+scales
+
+# Core
+enum34
+cachetools
+
+# Metadata cache
+lmdb
+
+# Graphite
+whisper
 git+https://github.com/graphite-project/carbon.git@master#egg=carbon
 git+https://github.com/graphite-project/graphite-web.git@master#egg=graphite-web

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ def _read(relpath):
 def _read_reqs(relpath):
     fullpath = os.path.join(os.path.dirname(__file__), relpath)
     with open(fullpath) as f:
-        return [s.strip() for s in f.readlines() if s.strip()]
+        return [s.strip() for s in f.readlines()
+                if (s.strip() and not s.startswith("#"))]
 
 
 _REQUIREMENTS_TXT = _read_reqs("requirements.txt")

--- a/tests/test_carbon.py
+++ b/tests/test_carbon.py
@@ -85,12 +85,11 @@ class TestCarbonDatabase(bg_test_utils.TestCaseWithFakeAccessor):
             self._plugin.setMetadata, _TEST_METRIC, "aggregationMethod", "avg")
 
     def test_write(self):
-        metric = bg_test_utils.make_metric(_TEST_METRIC)
         points = [(1, 42)]
-        self.accessor.create_metric(metric)
         # Writing twice (the first write is sync and the next one isn't)
-        self._plugin.write(metric.name, points)
-        self._plugin.write(metric.name, points)
+        self._plugin.write(_TEST_METRIC, points)
+        self._plugin.write(_TEST_METRIC, points)
+        metric = self.accessor.get_metric(_TEST_METRIC)
         actual_points = self.accessor.fetch_points(metric, 1, 2, stage=metric.retention[0])
         self.assertEqual(points, list(actual_points))
 

--- a/tests/test_carbon.py
+++ b/tests/test_carbon.py
@@ -46,7 +46,7 @@ class TestCarbonDatabase(bg_test_utils.TestCaseWithFakeAccessor):
         )
 
     def test_empty_settings(self):
-        database = bg_carbon.BigGraphiteDatabase(carbon_conf.Settings())
+        bg_carbon.BigGraphiteDatabase(carbon_conf.Settings())
 
     def test_get_fs_path(self):
         path = self._plugin.getFilesystemPath(_TEST_METRIC)

--- a/tests/test_carbon.py
+++ b/tests/test_carbon.py
@@ -21,7 +21,6 @@ import unittest
 
 from carbon import database
 from carbon import conf as carbon_conf
-from carbon import exceptions as carbon_exceptions
 
 from biggraphite.plugins import carbon as bg_carbon
 
@@ -48,8 +47,6 @@ class TestCarbonDatabase(bg_test_utils.TestCaseWithFakeAccessor):
 
     def test_empty_settings(self):
         database = bg_carbon.BigGraphiteDatabase(carbon_conf.Settings())
-        self.assertRaises(carbon_exceptions.CarbonConfigException,
-                          database.cache)
 
     def test_get_fs_path(self):
         path = self._plugin.getFilesystemPath(_TEST_METRIC)

--- a/tests/test_graphite_utils.py
+++ b/tests/test_graphite_utils.py
@@ -20,25 +20,7 @@ import unittest
 from biggraphite import graphite_utils as bg_graphite_utils
 
 
-class TestGraphiteUtilsInternals(unittest.TestCase):
-
-    def test_storage_path_from_settings(self):
-        settings = {}
-        self.assertRaises(bg_graphite_utils.ConfigError,
-                          bg_graphite_utils.storage_path, settings)
-
-        settings["STORAGE_DIR"] = "/"
-        self.assertEquals("/", bg_graphite_utils.storage_path(settings))
-
-
 class TestGraphiteUtils(unittest.TestCase):
-
-    def test_storage_path(self):
-        import types
-        settings = types.ModuleType("settings")
-        settings.STORAGE_DIR = "/tmp"
-        storage_path = bg_graphite_utils.storage_path(settings)
-        self.assertEquals(storage_path, settings.STORAGE_DIR)
 
     def test_accessor_from_settings(self):
         import types
@@ -46,6 +28,13 @@ class TestGraphiteUtils(unittest.TestCase):
         settings.BG_DRIVER = "memory"
         accessor = bg_graphite_utils.accessor_from_settings(settings)
         self.assertNotEquals(accessor, None)
+
+    def test_cache_from_settings(self):
+        import types
+        settings = types.ModuleType("settings")
+        settings.BG_CACHE = "memory"
+        cache = bg_graphite_utils.cache_from_settings('fake', settings)
+        self.assertNotEquals(cache, None)
 
 
 if __name__ == "__main__":

--- a/tests/test_metadata_cache.py
+++ b/tests/test_metadata_cache.py
@@ -18,11 +18,12 @@ from __future__ import print_function
 import unittest
 
 from biggraphite import test_utils as bg_test_utils
+from biggraphite import metadata_cache as bg_metadata_cache
 
 _TEST_METRIC = bg_test_utils.make_metric("a.b.c")
 
 
-class TestGraphiteUtilsInternals(bg_test_utils.TestCaseWithFakeAccessor):
+class CacheBaseTest(object):
 
     def _assert_hit_miss(self, hit, miss):
         self.assertEqual(hit, self.metadata_cache.hit_count)
@@ -83,7 +84,7 @@ class TestGraphiteUtilsInternals(bg_test_utils.TestCaseWithFakeAccessor):
         metric_name = "a.b.fake"
         metric = bg_test_utils.make_metric(metric_name)
 
-        self.metadata_cache._cache(metric)
+        self.metadata_cache._cache_set(metric_name, metric)
         self.metadata_cache.repair()
         self.metadata_cache.get_metric(metric_name)
         # repair() will remove it, and the get will produce a miss.
@@ -107,7 +108,7 @@ class TestGraphiteUtilsInternals(bg_test_utils.TestCaseWithFakeAccessor):
         metric_name = "a.b.fake"
         metric = bg_test_utils.make_metric(metric_name)
 
-        self.metadata_cache._cache(metric)
+        self.metadata_cache._cache_set(metric_name, metric)
 
         # Will not fix.
         self.metadata_cache.repair(start_key="b")
@@ -121,6 +122,16 @@ class TestGraphiteUtilsInternals(bg_test_utils.TestCaseWithFakeAccessor):
         # repair() will remove it, and the get will produce a miss.
         self.assertEquals(self.metadata_cache.hit_count, 2)
         self.assertEquals(self.metadata_cache.miss_count, 1)
+
+
+class TestDiskCache(CacheBaseTest, bg_test_utils.TestCaseWithFakeAccessor):
+
+    CACHE_CLASS = bg_metadata_cache.DiskCache
+
+
+class TestMemoryCache(CacheBaseTest, bg_test_utils.TestCaseWithFakeAccessor):
+
+    CACHE_CLASS = bg_metadata_cache.MemoryCache
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- don't perform useless operations if the source stage is
  the same as the output stage.
- really use a tuple factory instead of creating new objects
  for each point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/biggraphite/161)
<!-- Reviewable:end -->
