### PR TITLE
biggraphite: add a delayed writer

### DIFF
--- a/biggraphite/accessor.py
+++ b/biggraphite/accessor.py
@@ -688,6 +688,11 @@ class Accessor(object):
         """Return a sorted list of metric directories matching this glob."""
         self._check_connected()
 
+    @abc.abstractmethod
+    def flush(self):
+        """Flush any internal buffers."""
+        pass
+
     def insert_points(self, metric, datapoints):
         """Insert points for a given metric.
 
@@ -711,24 +716,24 @@ class Accessor(object):
             raise InvalidArgumentError("%s is not a Metric instance" % metric)
         self._check_connected()
 
-    def insert_downsampled_points(self, metric, downsampled):
+    def insert_downsampled_points(self, metric, datapoints):
         """Insert points for a given metric.
 
         Args:
           metric: The metric definition as per get_metric.
-          downsampled: An iterable of (timestamp in seconds, values as double, count as int, stage)
+          datapoints: An iterable of (timestamp in seconds, values as double, count as int, stage)
         """
         self._check_connected()
         _wait_async_call(
-            self.insert_downsampled_points_async, metric=metric, downsampled=downsampled)
+            self.insert_downsampled_points_async, metric=metric, datapoints=datapoints)
 
     @abc.abstractmethod
-    def insert_downsampled_points_async(self, metric, downsampled, on_done=None):
+    def insert_downsampled_points_async(self, metric, datapoints, on_done=None):
         """Insert points for a given metric.
 
         Args:
           metric: The metric definition as per get_metric.
-          downsampled: An iterable of (timestamp in seconds, values as double, count as int, stage)
+          datapoints: An iterable of (timestamp in seconds, values as double, count as int, stage)
           on_done(e: Exception): called on done, with an exception or None if succesfull
         """
         if not isinstance(metric, Metric):

--- a/biggraphite/cli/bgutil.py
+++ b/biggraphite/cli/bgutil.py
@@ -66,6 +66,7 @@ def main(args=None):
     bg_utils.set_log_level(settings)
     accessor = bg_utils.accessor_from_settings(settings)
     opts.func(accessor, opts)
+    accessor.flush()
 
 if __name__ == "__main__":
     main()

--- a/biggraphite/drivers/_delayed_writer.py
+++ b/biggraphite/drivers/_delayed_writer.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+# Copyright 2016 Criteo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Downsampling helpers for drivers that do not implement it server-side."""
+from __future__ import absolute_import
+from __future__ import print_function
+
+import collections
+import logging
+import time
+
+
+log = logging.getLogger(__name__)
+
+
+class DelayedWriter(object):
+    """Delay writes."""
+
+    DEFAULT_PERIOD_MS = 300000
+
+    def __init__(self, accessor, period_ms=DEFAULT_PERIOD_MS):
+        """Create a DelayedWriter.
+
+        The delayed writer will separate high resolution points and low
+        resolution points and will write the low resolution ones every
+        `period_ms` milliseconds.
+
+        For these points the value for a given timestamp is frequently
+        updated and we can safely delay the writes. In case of an unclean
+        shutdown we might loose up to `period_ms` points of data.
+
+        Args:
+          accessor: a connected accessor.
+          period_ms: delay before writing low resolution points.
+        """
+        self.accessor = accessor
+        self.period_ms = period_ms
+        self._queue = []
+        self._metrics_per_ms = 0
+        self._last_write_ms = time.time() * 1000
+        self._points = collections.defaultdict(dict)
+
+    def feed(self, metric, datapoints):
+        """Feed the delayed writer.
+
+        This function will seperate datapoints based on their
+        resolutions and keep the low resolution points for later.
+
+        Args:
+          mtric: the metric associated with these points.
+          datapoints: downsampled datapoints.
+
+        Returns:
+          list(datapoints) list of high resolution points that
+            should get written now.
+        """
+        high_res, low_res = [], []
+        for datapoint in datapoints:
+            _, _, _, stage = datapoint
+            # In case of unclean shutdown we could loose up to
+            # 10% of the data.
+            if stage.precision_ms < (self.period_ms * 10):
+                high_res.append(datapoint)
+            else:
+                low_res.append(datapoint)
+        self.write_later(metric, low_res)
+        # We piggy back on feed() to write delayed points, this works
+        # as long as we receive points regularly. We might want to add
+        # a timer at some point.
+        self.write_some()
+        return high_res
+
+    def flush(self):
+        """Flush all buffered points."""
+        self._build_queue()
+        while self._queue:
+            self.write_some(flush=True)
+
+    def write_later(self, metric, datapoints):
+        """Queue points for later."""
+        for datapoint in datapoints:
+            timestamp, value, count, stage = datapoint
+            self._points[metric][(stage, timestamp)] = (value, count)
+        self._build_queue()
+
+    def _build_queue(self):
+        """Build the queue of metrics to write."""
+        if len(self._queue) > 0:
+            return
+        # Order by number of points.
+        self._queue = sorted(
+            self._points.keys(),
+            key=lambda k: len(self._points[k])
+        )
+        # We know that we have up to `period_ms` to write everything
+        # so let's write only a few metrics per iteration.
+        self._metrics_per_ms = float(len(self._queue)) / self.period_ms
+        log.debug("rebuilt the queues: %d metrics, %d per second",
+                  len(self._queue), self._metrics_per_ms)
+
+    def write_some(self, flush=False):
+        """Write some points from the queue."""
+        now = time.time() * 1000
+        delta_ms = (now - self._last_write_ms) + 1
+        if flush:
+            metrics_to_write = len(self._queue)
+        else:
+            metrics_to_write = round(delta_ms * self._metrics_per_ms)
+        if metrics_to_write == 0:
+            return
+        i = 0
+        log.debug("writing low res points for %d metrics" % metrics_to_write)
+        while self._queue and i < metrics_to_write:
+            metric = self._queue.pop()
+            datapoints = []
+            for k, v in self._points[metric].items():
+                stage, timestamp = k
+                value, count = v
+                i += 1
+                datapoints.append((timestamp, value, count, stage))
+            self.accessor.insert_downsampled_points_async(metric, datapoints)
+        self._last_write_ms = now

--- a/tests/test_carbon.py
+++ b/tests/test_carbon.py
@@ -86,6 +86,7 @@ class TestCarbonDatabase(bg_test_utils.TestCaseWithFakeAccessor):
         # Writing twice (the first write is sync and the next one isn't)
         self._plugin.write(_TEST_METRIC, points)
         self._plugin.write(_TEST_METRIC, points)
+        self.accessor.flush()
         metric = self.accessor.get_metric(_TEST_METRIC)
         actual_points = self.accessor.fetch_points(metric, 1, 2, stage=metric.retention[0])
         self.assertEqual(points, list(actual_points))
@@ -96,6 +97,7 @@ class TestCarbonDatabase(bg_test_utils.TestCaseWithFakeAccessor):
         points = [(1, 42)]
         self.accessor.create_metric(metric)
         self._plugin.write(metric.name, points)
+        self.accessor.flush()
 
         self.assertEqual(True, self.accessor.has_metric("a.b..c"))
         self.assertNotEqual(None, self.accessor.get_metric("a.b..c"))

--- a/tests/test_cassandra.py
+++ b/tests/test_cassandra.py
@@ -50,6 +50,7 @@ class TestAccessorWithCassandra(bg_test_utils.TestCaseWithAccessor):
     def test_fetch_empty(self):
         no_such_metric = bg_test_utils.make_metric("no.such.metric")
         self.accessor.insert_points(_METRIC, _POINTS)
+        self.accessor.flush()
         self.accessor.drop_all_metrics()
         self.assertEqual(
             len(self.fetch(no_such_metric, _POINTS_START, _POINTS_END)),
@@ -64,9 +65,11 @@ class TestAccessorWithCassandra(bg_test_utils.TestCaseWithAccessor):
         # We've had a regression where inserting empty list would freeze
         # the process
         self.accessor.insert_points(_METRIC, [])
+        self.accessor.flush()
 
     def test_insert_fetch(self):
         self.accessor.insert_points(_METRIC, _POINTS)
+        self.accessor.flush()
         self.addCleanup(self.accessor.drop_all_metrics)
 
         # TODO: Test fetch at different stages for a given metric.
@@ -95,7 +98,7 @@ class TestAccessorWithCassandra(bg_test_utils.TestCaseWithAccessor):
         # that breaking changes aren't introduced to the schema.
         self.accessor.create_metric(_METRIC)
         self.accessor.insert_points(_METRIC, _POINTS)
-
+        self.accessor.flush()
         self.cluster.refresh_schema_metadata()
 
         keyspace = None
@@ -144,7 +147,7 @@ class TestAccessorWithCassandra(bg_test_utils.TestCaseWithAccessor):
         # that breaking changes aren't introduced to the schema.
         self.accessor.create_metric(_METRIC)
         self.accessor.insert_points(_METRIC, _POINTS)
-
+        self.accessor.flush()
         self.cluster.refresh_schema_metadata()
 
         keyspace = None
@@ -269,6 +272,7 @@ class TestAccessorWithCassandra(bg_test_utils.TestCaseWithAccessor):
         self.assertNotEqual(None, self.accessor.get_metric("a.b..c"))
 
         self.accessor.insert_points(metric, points)
+        self.accessor.flush()
         actual_points = self.accessor.fetch_points(metric, 1, 2, stage=metric.retention[0])
         self.assertEqual(points, list(actual_points))
         actual_points = self.accessor.fetch_points(metric_1, 1, 2, stage=metric.retention[0])

--- a/tests/test_drivers_downsampling.py
+++ b/tests/test_drivers_downsampling.py
@@ -19,7 +19,11 @@ import unittest
 import uuid
 
 from biggraphite import accessor as bg_accessor
+from biggraphite import test_utils
 from biggraphite.drivers import _downsampling as bg_ds
+
+
+test_utils.setup_logging()
 
 
 class TestDownsampler(unittest.TestCase):
@@ -186,6 +190,21 @@ class TestDownsampler(unittest.TestCase):
         expected = expected_stage_0 + expected_stage_1
         result = self.ds.feed(self.metric_sum, points)
         self.assertEqual(result, expected)
+
+    def test_purge(self):
+        """Test that we purge old metrics correctly."""
+        points = [
+            (1, 1),
+        ]
+        self.ds.feed(self.metric_sum, points)
+
+        # Should no remove anything.
+        self.ds.purge(now=1)
+        self.assertEquals(len(self.ds._names_to_aggregates), 1)
+
+        # Should remove everything.
+        self.ds.purge(now=(self.PRECISION ** 2) * 3)
+        self.assertEquals(len(self.ds._names_to_aggregates), 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_glob_utils.py
+++ b/tests/test_glob_utils.py
@@ -151,7 +151,6 @@ class TestGlobUtils(bg_test_utils.TestCaseWithFakeAccessor):
             ("a.**", ["a.a.a", "a.b.c", "a.b.d"], ["a.a", "a.b"]),
         ]
         for (glob, metrics, directories) in scenarii:
-            print(glob, metrics, directories)
             found = bg_glob.graphite_glob(self.accessor, glob)
             self.assertEqual((metrics, directories), found)
 

--- a/tests/test_graphite.py
+++ b/tests/test_graphite.py
@@ -59,7 +59,7 @@ class TestReader(bg_test_utils.TestCaseWithFakeAccessor):
 
     _POINTS_START = 3600 * 24 * 10
     _POINTS_END = _POINTS_START + 3600
-    _RETENTION = bg_accessor.Retention.from_string("20*15s:1440*60s")
+    _RETENTION = bg_accessor.Retention.from_string("20*15s:1440*60s:48*3600s")
     _POINTS = _make_easily_queryable_points(
         start=_POINTS_START, end=_POINTS_END, period=_RETENTION[1].precision,
     )
@@ -70,6 +70,7 @@ class TestReader(bg_test_utils.TestCaseWithFakeAccessor):
         self.accessor.connect()
         self.accessor.create_metric(self._METRIC)
         self.accessor.insert_points(self._METRIC, self._POINTS)
+        self.accessor.flush()
         self.reader = bg_graphite.Reader(self.accessor, self.metadata_cache, _METRIC_NAME)
 
     def fetch(self, *args, **kwargs):
@@ -95,7 +96,7 @@ class TestReader(bg_test_utils.TestCaseWithFakeAccessor):
 
     def test_get_intervals(self):
         # start and end are the expected results, aligned on the precision
-        now_rounded = 10000000 * self._RETENTION[0].precision
+        now_rounded = 10000000 * self._RETENTION[2].precision
         now = now_rounded - 3
         res = self.reader.get_intervals(now=now)
 


### PR DESCRIPTION
The delayed writer will separate low res and high res points
and write the low resolution points slower. This gives
batching for free because these points usually have the same
timestamp and a value that changes over time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/biggraphite/162)
<!-- Reviewable:end -->
