### PR TITLE
metadata_cache: fix DiskCache.has_metric()

### DIFF
--- a/biggraphite/metadata_cache.py
+++ b/biggraphite/metadata_cache.py
@@ -312,7 +312,8 @@ class DiskCache(Cache):
         """Check if metric is cached."""
         encoded_metric_name = bg_accessor.encode_metric_name(metric_name)
         with self.__env.begin(self.__metric_to_metadata_db, write=False) as txn:
-            return bool(txn.get(encoded_metric_name))
+            payload = txn.get(encoded_metric_name)
+            return payload is not None and payload != self._EMPTY
 
     def __expired_timestamp(self, timestamp):
         """Check if timestamp is expired.

--- a/tests/test_metadata_cache.py
+++ b/tests/test_metadata_cache.py
@@ -55,6 +55,7 @@ class CacheBaseTest(object):
         name = _TEST_METRIC.name
         self.assertEquals(self.metadata_cache.has_metric(name), False)
         self.assertEquals(self.metadata_cache.get_metric(name), None)
+        self.assertEquals(self.metadata_cache.has_metric(name), False)
 
         self.metadata_cache.create_metric(_TEST_METRIC)
         self.assertEquals(self.metadata_cache.has_metric(name), True)


### PR DESCRIPTION
Before it would return True when a miss was being cached.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/biggraphite/167)
<!-- Reviewable:end -->
