### PR TITLE
Touch metrics in Cassandra backend on timestamp cache update.

### DIFF
--- a/biggraphite/accessor.py
+++ b/biggraphite/accessor.py
@@ -748,6 +748,11 @@ class Accessor(object):
         self._check_connected()
 
     @abc.abstractmethod
+    def clean(self, cutoff, batch_size=10000):
+        """Clean the metadata from metrics older than the cutoff timestamp."""
+        self._check_connected()
+
+    @abc.abstractmethod
     def repair(self, start_key=None, end_key=None, shard=0, nshards=1):
         """Repair potential corruptions in the database.
 

--- a/biggraphite/accessor.py
+++ b/biggraphite/accessor.py
@@ -616,6 +616,13 @@ class Accessor(object):
             raise InvalidArgumentError("%s is not a Metric instance" % metric)
         self._check_connected()
 
+    @abc.abstractmethod
+    def touch_metric(self, metric):
+        """Touch a metric to update its last write timestamp."""
+        if not isinstance(metric, Metric):
+            raise InvalidArgumentError("%s is not a Metric instance" % metric)
+        self._check_connected()
+
     def _check_connected(self):
         if not self.is_connected:
             raise Error("Accessor's connect() wasn't called")

--- a/biggraphite/cli/bgutil.py
+++ b/biggraphite/cli/bgutil.py
@@ -74,5 +74,6 @@ def main(args=None, accessor=None):
     opts.func(accessor, opts)
     accessor.flush()
 
+
 if __name__ == "__main__":
     main()

--- a/biggraphite/cli/command_clean.py
+++ b/biggraphite/cli/command_clean.py
@@ -30,12 +30,12 @@ class CommandClean(command.BaseCommand):
     def add_arguments(self, parser):
         """Add custom arguments."""
         parser.add_argument(
-            "--cache",
+            "--clean-cache",
             help="clean cache",
             action='store_true'
         )
         parser.add_argument(
-            "--backend",
+            "--clean-backend",
             help="clean backend",
             action='store_true'
         )
@@ -68,9 +68,11 @@ class CommandClean(command.BaseCommand):
             if opts.storage_dir:
                 cache = metadata_cache.DiskCache(accessor, opts.storage_dir)
                 cache.open()
-                cache.clean()
+                logging.info('Cleaning cache...')
+                cache.clean(cutoff)
             else:
                 logging.warning('Cannot clean disk cache because storage_dir is empty')
 
         if opts.backend:
+            logging.info('Cleaning backend..')
             accessor.clean(cutoff, opts.batch_size)

--- a/biggraphite/cli/import_whisper.py
+++ b/biggraphite/cli/import_whisper.py
@@ -215,5 +215,6 @@ def main(args=None):
 
     print("Uploaded", len(paths), "metrics containing", total_points, "points", file=out_fd)
 
+
 if __name__ == "__main__":
     main()

--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -148,6 +148,7 @@ class InvalidArgumentError(Error, bg_accessor.InvalidArgumentError):
 class InvalidGlobError(InvalidArgumentError):
     """The provided glob is invalid."""
 
+
 # TODO(c.chary): convert some of these to options, but make sure
 # they are stored in the database an loaded automatically from
 # here.

--- a/biggraphite/drivers/memory.py
+++ b/biggraphite/drivers/memory.py
@@ -123,6 +123,11 @@ class _MemoryAccessor(bg_accessor.Accessor):
             path.append(part)
             self._directory_names.add(".".join(path))
 
+    # TODO: implement touch metric for memory driver
+    def touch_metric(self, metric):
+        """See the real Accessor for a description."""
+        pass
+
     @staticmethod
     def __glob_names(names, glob):
         results = bg_glob.glob(names, glob)

--- a/biggraphite/drivers/memory.py
+++ b/biggraphite/drivers/memory.py
@@ -123,7 +123,8 @@ class _MemoryAccessor(bg_accessor.Accessor):
             path.append(part)
             self._directory_names.add(".".join(path))
 
-    # TODO: implement touch metric for memory driver
+    # TODO(r.veznaver): implement touch metric for memory driver
+    #                   (requires implementing TTL or timestamp support)
     def touch_metric(self, metric):
         """See the real Accessor for a description."""
         pass

--- a/biggraphite/drivers/memory.py
+++ b/biggraphite/drivers/memory.py
@@ -129,6 +129,12 @@ class _MemoryAccessor(bg_accessor.Accessor):
         """See the real Accessor for a description."""
         pass
 
+    # TODO(r.veznaver): implement clean metrics for memory driver
+    #                   (requires implementing TTL or timestamp support)
+    def clean(self, *args, **kwargs):
+        """See the real Accessor for a description."""
+        pass
+
     @staticmethod
     def __glob_names(names, glob):
         results = bg_glob.glob(names, glob)

--- a/biggraphite/metadata_cache.py
+++ b/biggraphite/metadata_cache.py
@@ -125,7 +125,7 @@ class Cache(object):
         return metric
 
     @abc.abstractmethod
-    def clean(self):
+    def clean(self, cutoff=None):
         """Clean the cache from expired metrics."""
         pass
 
@@ -205,7 +205,7 @@ class MemoryCache(Cache):
         if metric:
             self.__cache[metric_name] = metric
 
-    def clean(self):
+    def clean(self, cutoff=None):
         """Automatically cleaned by cachetools."""
         pass
 
@@ -436,13 +436,14 @@ class DiskCache(Cache):
             return None
         return (metric_id, metric_metadata, timestamp)
 
-    def clean(self):
+    def clean(self, cutoff=None):
         """Remove all expired metrics.
 
         Note: This will also remove metrics without a timestamp or
               whose timestamp value is not a digit.
         """
-        cutoff = int(time.time()) - int(self.__ttl)
+        if not cutoff:
+            cutoff = int(time.time()) - int(self.__ttl)
         logging.info("Cleaning cache with cutoff time %d" % cutoff)
 
         with self.__env.begin(self.__metric_to_metadata_db, write=True) as txn:

--- a/biggraphite/test_utils.py
+++ b/biggraphite/test_utils.py
@@ -114,6 +114,7 @@ def prepare_graphite_imports():
             if path not in sys.path:
                 sys.path.insert(0, path)
 
+
 _UUID_NAMESPACE = uuid.UUID('{00000000-0000-0000-0000-000000000000}')
 
 

--- a/tests/test_cassandra.py
+++ b/tests/test_cassandra.py
@@ -15,6 +15,7 @@
 from __future__ import print_function
 
 import unittest
+import time
 
 from biggraphite import accessor as bg_accessor
 from biggraphite import test_utils as bg_test_utils
@@ -262,6 +263,14 @@ class TestAccessorWithCassandra(bg_test_utils.TestCaseWithAccessor):
         self.assertEquals(self.accessor.has_metric(metric.name), False)
         self.accessor.create_metric(metric)
         self.assertEquals(self.accessor.has_metric(metric.name), True)
+
+    def test_clean(self):
+        metric = self.make_metric("a.b.c.d.e.f")
+        self.accessor.create_metric(metric)
+        # set cutoff time in the future to delete all created metrics
+        cutoff = int(time.time() + 3600)
+        self.accessor.clean(cutoff, 0)
+        self.assertEquals(self.accessor.has_metric(metric.name), False)
 
     def test_repair(self):
         # TODO(c.chary): Add better test for repair()

--- a/tests/test_cassandra.py
+++ b/tests/test_cassandra.py
@@ -265,12 +265,15 @@ class TestAccessorWithCassandra(bg_test_utils.TestCaseWithAccessor):
         self.assertEquals(self.accessor.has_metric(metric.name), True)
 
     def test_clean(self):
-        metric = self.make_metric("a.b.c.d.e.f")
-        self.accessor.create_metric(metric)
+        metric1 = self.make_metric("a.b.c.d.e.f")
+        self.accessor.create_metric(metric1)
+        metric2 = self.make_metric("g.h.i.j.k.l")
+        self.accessor.create_metric(metric2)
         # set cutoff time in the future to delete all created metrics
         cutoff = int(time.time() + 3600)
-        self.accessor.clean(cutoff, 0)
-        self.assertEquals(self.accessor.has_metric(metric.name), False)
+        self.accessor.clean(cutoff, 10)
+        self.assertEquals(self.accessor.has_metric(metric1.name), False)
+        self.assertEquals(self.accessor.has_metric(metric2.name), False)
 
     def test_repair(self):
         # TODO(c.chary): Add better test for repair()

--- a/tests/test_cassandra.py
+++ b/tests/test_cassandra.py
@@ -249,6 +249,13 @@ class TestAccessorWithCassandra(bg_test_utils.TestCaseWithAccessor):
         for k, v in meta_dict.iteritems():
             self.assertEqual(v, getattr(metric_again.metadata, k))
 
+    def test_touch_metric(self):
+        metric = self.make_metric("a.b.c.d.e.f")
+
+        self.accessor.create_metric(metric)
+        self.accessor.touch_metric(metric)
+        self.assertEquals(self.accessor.has_metric(metric.name), True)
+
     def test_has_metric(self):
         metric = self.make_metric("a.b.c.d.e.f")
 

--- a/tests/test_command_du.py
+++ b/tests/test_command_du.py
@@ -67,5 +67,6 @@ class TestCommandDu(bg_test_utils.TestCaseWithFakeAccessor):
         self.assertEqual(du._human_size_of_points(1023 / command_du._BYTES_PER_POINT), '1008B')
         self.assertEqual(du._human_size_of_points(1024 / (command_du._BYTES_PER_POINT-1)), '1.0K')
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_command_repair.py
+++ b/tests/test_command_repair.py
@@ -33,5 +33,6 @@ class TestCommandRepair(bg_test_utils.TestCaseWithFakeAccessor):
         opts = parser.parse_args(['--shard=0', '--nshards=5'])
         cmd.run(self.accessor, opts)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_command_test.py
+++ b/tests/test_command_test.py
@@ -33,5 +33,6 @@ class TestCommandRepair(bg_test_utils.TestCaseWithFakeAccessor):
         opts = parser.parse_args(['--shard=0', '--nshards=5'])
         cmd.run(self.accessor, opts)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_glob_utils.py
+++ b/tests/test_glob_utils.py
@@ -154,5 +154,6 @@ class TestGlobUtils(bg_test_utils.TestCaseWithFakeAccessor):
             found = bg_glob.graphite_glob(self.accessor, glob)
             self.assertEqual((metrics, directories), found)
 
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Touching the metric in the backend metadata table will enable us to clean expired metrics based on ```WRITETIME (config)``` where config is the metric metadata. This avoids changing the data structure since, unlike lmdb, the write timestamp is already present for a given value.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/biggraphite/170)
<!-- Reviewable:end -->
