### PR TITLE
Initial implementation of query optimization for Cassandra

### DIFF
--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -17,6 +17,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import itertools
 import logging
 import uuid
 import os
@@ -33,6 +34,7 @@ from cassandra import policies as c_policies
 from cassandra.io import asyncorereactor as c_asyncorereactor
 
 from biggraphite import accessor as bg_accessor
+from biggraphite import glob_utils as bg_glob
 from biggraphite.drivers import _downsampling
 from biggraphite.drivers import _delayed_writer
 from biggraphite.drivers import _utils
@@ -527,6 +529,7 @@ class _CassandraAccessor(bg_accessor.Accessor):
         self.__insert_metrics_statement = None  # setup by connect()
         self.__select_metric_statement = None  # setup by connect()
         self.__session = None  # setup by connect()
+        self.__glob_parser = bg_glob.GraphiteGlobParser()
 
     def connect(self, skip_schema_upgrade=False):
         """See bg_accessor.Accessor."""
@@ -807,43 +810,55 @@ class _CassandraAccessor(bg_accessor.Accessor):
         return self.__glob_names("metrics", glob)
 
     def __glob_names(self, table, glob):
-        components = self._components_from_name(glob)
+        components = self.__glob_parser.parse(glob)
         if len(components) > _COMPONENTS_MAX_LEN:
-            msg = "Metric globs can have a maximum of %d dots" % _COMPONENTS_MAX_LEN - 2
-            raise bg_accessor.InvalidGlobError(msg)
+            raise bg_accessor.InvalidGlobError(
+                "Contains %d components, but we support %d at most" % (
+                    len(components),
+                    _COMPONENTS_MAX_LEN,
+                )
+            )
 
         queries = []
-
-        # Handle globstars (any number of wildcards at its position in the path)
-        if GLOBSTAR in components:
-            if components.count(GLOBSTAR) > 1:
-                # For performance reasons, we will not handle more than one of these
-                msg = "Metric globs can have a maximum of one globstar (**)"
-                raise bg_accessor.InvalidGlobError(msg)
-
-            # If the globstar is at the end, just drop the last component marker;
-            # otherwise we have to use iterative deepening with wildcards.
-            gs_index = components.index(GLOBSTAR)
-            before_last = - 2
-            if gs_index == len(components) + before_last:
-                gs_query = self.__build_select_metric_names_query(
-                    table, components[:before_last], glob, is_raw=True)
-                queries.append(gs_query)
-            else:
-                prefix = components[0:gs_index]
-                suffix = components[gs_index+1:]
-                max_wildcards = min(
-                    self.max_wildcards_for_globstar,
-                    _COMPONENTS_MAX_LEN - len(components)
+        globstar = bg_glob.Globstar()
+        if globstar in components:
+            # Handling more than one of these can cause combinatorial explosion.
+            if components.count(globstar) > 1:
+                raise bg_accessor.InvalidGlobError(
+                    "Contains more than one globstar (**) operator"
                 )
+
+            # If the globstar operator is at the end of the pattern, then we can
+            # find corresponding metrics with a prefix search;
+            # otherwise, we have to generate incremental queries that go up to a
+            # certain depth (_COMPONENTS_MAX_LEN - #components).
+            gs_index = components.index(globstar)
+            if gs_index == len(components) - 1:
+                queries.append(
+                    self.__build_select_names_query(
+                        table, components[:gs_index], glob,
+                    )
+                )
+            else:
+                prefix = components[:gs_index]
+                suffix = components[gs_index+1:] + [[_LAST_COMPONENT]]
+                max_wildcards = min(self.max_wildcards_for_globstar,
+                                    _COMPONENTS_MAX_LEN - len(components))
                 for wildcards in range(1, max_wildcards):
-                    gs_components = prefix + (["*"] * wildcards) + suffix
-                    gs_query = self.__build_select_metric_names_query(
-                        table, gs_components, glob)
-                    queries.append(gs_query)
+                    gs_components = (prefix +
+                                     ([[bg_glob.AnySequence()]] * wildcards) +
+                                     suffix)
+                    queries.append(
+                        self.__build_select_names_query(
+                            table, gs_components, glob,
+                        )
+                    )
         else:
-            query = self.__build_select_metric_names_query(table, components, glob)
-            queries.append(query)
+            queries.append(
+                self.__build_select_names_query(
+                    table, components + [[_LAST_COMPONENT]], glob,
+                )
+            )
 
         metric_names = []
         try:
@@ -858,64 +873,93 @@ class _CassandraAccessor(bg_accessor.Accessor):
             raise RetryableCassandraError(e)
 
         if len(metric_names) > self.max_metrics_per_glob:
-            msg = "%s yields more than %d results" % (glob, self.max_metrics_per_glob)
-            raise TooManyMetrics(msg)
+            raise TooManyMetrics(
+                "Query yields more than %d results" %
+                (self.max_metrics_per_glob)
+            )
 
         metric_names.sort()
         return metric_names
 
-    def __build_select_metric_names_query(self, table, components, glob, is_raw=False):
-        """Build a select query to find metric names (table can be directories or metrics).
+    def __build_select_names_query(self, table, components, glob):
+        query_select = "SELECT name FROM \"%s\".\"%s\"" % (
+            self.keyspace_metadata,
+            table,
+        )
+        query_limit = "LIMIT %d" % (self.max_metrics_per_glob + 1)
 
-        Args:
-          table: Table name from which to select the rows.
-          components: Individual components from the glob.
-          glob: Globbing pattern we are generating the query for.
-          is_raw: True when we want to force WHERE clause generation without checking.
+        if len(components) == 0:
+            return "%s %s;" % (query_select, query_limit)
 
-        Returns:
-          Query string that is ready to be executed.
-        """
-        # Check if it's something like foo.bar.* with a single trailing wildcard.
-        if components.count('*') == 1 and components[-2] == '*':
-            idx = components.index("*")
-            prefix = ".".join(components[0:idx])
-            components = ['*'] * (idx + 1) + components[idx+1:]
-        else:
-            prefix = None
-
-        where_parts = [
-            "component_%d = %s" % (n, c_encoder.cql_quote(s))
-            for n, s in enumerate(components)
-            if s != "*"
-        ]
-        if prefix:
-            where_parts.append("parent = '%s.'" % prefix)
-
-        if is_raw or len(where_parts) != len(components):
-            if len(where_parts) == 0:
-                # Avoid pesky syntax errors in case someone queries for "**"
-                where = ""
+        # If all components are constant values we can search by exact name.
+        # If all but the last component are constant values we can search by
+        # exact parent, in which case we may benefit from filtering the last
+        # component by prefix when we have one. (Code refers to the previous-to
+        # -last component because of the __END__ suffix we use).
+        #
+        # We are not using prefix search on the parent because it appears to be
+        # too slow/costly at the moment (see #174 for details).
+        if (
+            components[-1] == [_LAST_COMPONENT] and  # Not a prefix globstar
+            all(len(c) == 1 and isinstance(c[0], str) for c in components[:-2])
+        ):
+            last = components[-2]
+            if len(last) == 1 and isinstance(last[0], str):
+                return "%s WHERE name = %s %s;" % (
+                    query_select,
+                    c_encoder.cql_quote(glob),
+                    query_limit,
+                )
             else:
-                where = "WHERE " + " AND ".join(where_parts)
-            filtering = True
-        else:
-            # No wildcard, skip indexes
-            where = "WHERE name = " + c_encoder.cql_quote(glob)
-            filtering = False
+                if len(last) > 0 and isinstance(last[0], str):
+                    prefix_filter = "AND component_%d LIKE %s" % (
+                        len(components) - 1,
+                        c_encoder.cql_quote(last[0] + '%'),
+                    )
+                    allow_filtering = "ALLOW FILTERING"
+                else:
+                    prefix_filter = ''
+                    allow_filtering = ''
 
-        query = (
-            "SELECT name FROM \"%(keyspace)s\".\"%(table)s\""
-            " %(where)s LIMIT %(limit)d %(filtering)s;"
-        ) % {
-            "keyspace": self.keyspace_metadata,
-            "table": table,
-            "where": where,
-            "limit": self.max_metrics_per_glob + 1,
-            "filtering": "ALLOW FILTERING" if filtering else ""
-        }
+                parent = itertools.chain.from_iterable(components[:-2])
+                parent = '.'.join(parent) + '.'
+                return "%s WHERE parent = %s %s %s %s;" % (
+                    query_select,
+                    c_encoder.cql_quote(parent),
+                    prefix_filter,
+                    query_limit,
+                    allow_filtering,
+                )
 
-        return query
+        where_clauses = []
+        for n, component in enumerate(components):
+            if len(component) == 0:
+                continue
+
+            # We are currently using prefix indexes, so if we do not have a
+            # prefix value (i.e. it is a wildcard), then the current component
+            # cannot be constrained inside the request.
+            value = component[0]
+            if not isinstance(value, str):
+                continue
+
+            if len(component) == 1:
+                op = '='
+            else:
+                op = "LIKE"
+                value += '%'
+
+            clause = "component_%d %s %s" % (n, op, c_encoder.cql_quote(value))
+            where_clauses.append(clause)
+
+        if len(where_clauses) == 0:
+            return "%s %s;" % (query_select, query_limit)
+
+        return "%s WHERE %s %s ALLOW FILTERING;" % (
+            query_select,
+            " AND ".join(where_clauses),
+            query_limit
+        )
 
     def flush(self):
         """Flush any internal buffers."""

--- a/biggraphite/glob_utils.py
+++ b/biggraphite/glob_utils.py
@@ -26,16 +26,6 @@ def _is_graphite_glob(metric_component):
     return _GRAPHITE_GLOB_RE.match(metric_component) is None
 
 
-def _graphite_glob_to_accessor_components(graphite_glob):
-    """Transform Graphite glob into Cassandra accessor components."""
-    return ".".join([
-        "**" if c == "**" else
-        "*" if _is_graphite_glob(c) else
-        c
-        for c in graphite_glob.split(".")
-    ])
-
-
 def _is_valid_glob(glob):
     """Check whether a glob pattern is valid.
 
@@ -209,12 +199,11 @@ def graphite_glob(accessor, graphite_glob):
         return ([], [])
 
     glob_re = re.compile(_glob_to_regex(graphite_glob))
-    accessor_components = _graphite_glob_to_accessor_components(graphite_glob)
 
-    metrics = accessor.glob_metric_names(accessor_components)
+    metrics = accessor.glob_metric_names(graphite_glob)
     metrics = filter(glob_re.match, metrics)
 
-    directories = accessor.glob_directory_names(accessor_components)
+    directories = accessor.glob_directory_names(graphite_glob)
     directories = filter(glob_re.match, directories)
     return (metrics, directories)
 

--- a/biggraphite/glob_utils.py
+++ b/biggraphite/glob_utils.py
@@ -217,3 +217,180 @@ def graphite_glob(accessor, graphite_glob):
     directories = accessor.glob_directory_names(accessor_components)
     directories = filter(glob_re.match, directories)
     return (metrics, directories)
+
+
+class GlobExpression:
+    """Base class for glob expressions."""
+
+    def __repr__(self):
+        return self.__class__.__name__
+
+    def __eq__(self, other):
+        return self.__class__ == other.__class__
+
+
+class GlobExpressionWithValues(GlobExpression):
+    """Base class for glob expressions that have values."""
+
+    def __init__(self, values):
+        """Take a list of values, and stores the sorted unique values."""
+        self.values = sorted(set(values))
+
+    def __repr__(self):
+        return "%s(%s)" % (self.__class__.__name__, self.values)
+
+    def __eq__(self, other):
+        return (GlobExpression.__eq__(self, other) and
+                self.values == other.values)
+
+
+class Globstar(GlobExpression):
+    """Represents a globstar wildcard."""
+
+    pass
+
+
+class AnyChar(GlobExpression):
+    """Represents any single character in a glob."""
+
+    pass
+
+
+class AnySequence(GlobExpression):
+    """Represents any sequence of 0 or more characters in a glob."""
+
+    pass
+
+
+class GraphiteGlobParser:
+    """Utility class for parsing graphite glob expressions."""
+
+    def __init__(self):
+        """Build a parser, fill in default values."""
+        self._glob = ''
+        self._reset()
+
+    def _commit_sequence(self):
+        if len(self._sequence) > 0:
+            self._component.append(self._sequence)
+            self._sequence = ''
+
+    def _commit_component(self):
+        self._commit_sequence()
+        if len(self._component) > 0:
+            self._parsed.append(self._component)
+            self._component = []
+
+    def _parse_char_wildcard(self):
+        """Parse single character wildcard."""
+        self._commit_sequence()
+        self._component.append(AnyChar())
+
+    def _parse_wildcard(self, i, n):
+        """Parse multi-character wildcard, and globstar."""
+        self._commit_sequence()
+        # Look-ahead for potential globstar
+        if i < n and self._glob[i] == '*':
+            self._commit_component()
+            self._parsed.append(Globstar())
+            i += 1
+        else:
+            self._component.append(AnySequence())
+
+        return i
+
+    def _parse_char_selector(self, i, n):
+        """Parse character selector, with support for negation and ranges.
+
+        For simplicity (and because it does not seem useful at the moment) we
+        will not be generating the possible values or parsing the ranges, but
+        outputting AnyChar on valid char selector expressions.
+        """
+        j = i
+        if j < n and self._glob[j] == '!':
+            j += 1
+        if j < n and self._glob[j] == ']':
+            j += 1
+        while j < n and self._glob[j] != ']':
+            j += 1
+
+        if j < n:
+            # +1 to skip closing bracket
+            i = j + 1
+            self._commit_sequence()
+            self._component.append(AnyChar())
+        else:
+            # Reached end of string: unbalanced bracket
+            self._sequence += '['
+
+        return i
+
+    def _parse_sequence_selector(self, i, n):
+        """Parse character sequence selector, with nesting.
+
+        For simplicity (and because it does not seem useful at the moment) we
+        will not be generating the possible values, but outputting AnySequence
+        on valid char sequence selector expressions.
+        """
+        depth = 1
+        j = i
+        while j < n and depth > 0:
+            c = self._glob[j]
+            j += 1
+            if c == '{':
+                depth += 1
+            elif c == '}':
+                depth -= 1
+            elif c == '.':
+                # We have a component separator, this selector is wrong
+                #
+                # XXX(d.forest): this is purposefully simplified, but maybe we
+                #                should handle escaped dots, or dots within char
+                #                selectors?
+                break
+
+        if depth == 0:
+            i = j
+            self._commit_sequence()
+            self._component.append(AnySequence())
+        else:
+            # Reached end of string: braces are unbalanced
+            self._sequence += '{'
+
+        return i
+
+    def _reset(self, glob=''):
+        if glob == self._glob:
+            return
+
+        self._glob = glob
+        self._parsed = []
+        self._component = []
+        self._sequence = ''
+
+    def parse(self, glob):
+        """Parse a graphite glob expression into simple components."""
+        self._reset(glob)
+        if self._parsed:
+            return self._parsed
+
+        i = 0
+        n = len(self._glob)
+        while i < n:
+            c = self._glob[i]
+            i += 1
+            if c == '?':
+                self._parse_char_wildcard()
+            elif c == '*':
+                i = self._parse_wildcard(i, n)
+            elif c == '[':
+                i = self._parse_char_selector(i, n)
+            elif c == '{':
+                i = self._parse_sequence_selector(i, n)
+            elif c == '.':
+                self._commit_component()
+            else:
+                self._sequence += c
+
+        self._commit_component()
+        return self._parsed

--- a/tests/test_glob_utils.py
+++ b/tests/test_glob_utils.py
@@ -65,20 +65,6 @@ class TestGlobUtilsInternals(unittest.TestCase):
         for x in invalid_glob:
             self.assertFalse(bg_glob._is_valid_glob(x))
 
-    def test_graphite_glob_to_accessor_components(self):
-        scenarii = [
-            ('a.*.b', 'a.*.b'),
-            ('a.?.b', 'a.*.b'),
-            ('a?.b',      '*.b'),
-            ('a{x,y}.b',  '*.b'),
-            ('a{x,y}z.b', '*.b'),
-            ('a[0-9].b',  '*.b'),
-            ('a[0-9]z.b', '*.b'),
-        ]
-        for (glob, components) in scenarii:
-            simplified = bg_glob._graphite_glob_to_accessor_components(glob)
-            self.assertEqual(components, simplified)
-
     def test_glob_to_regex(self):
         def filter_metrics(metrics, glob):
             glob_re = re.compile(bg_glob._glob_to_regex(glob))

--- a/tests/test_glob_utils.py
+++ b/tests/test_glob_utils.py
@@ -76,7 +76,8 @@ class TestGlobUtilsInternals(unittest.TestCase):
             ('a[0-9]z.b', '*.b'),
         ]
         for (glob, components) in scenarii:
-            self.assertEqual(components, bg_glob._graphite_glob_to_accessor_components(glob))
+            simplified = bg_glob._graphite_glob_to_accessor_components(glob)
+            self.assertEqual(components, simplified)
 
     def test_glob_to_regex(self):
         def filter_metrics(metrics, glob):
@@ -92,10 +93,47 @@ class TestGlobUtilsInternals(unittest.TestCase):
             (['a.b', 'a.b.c', 'a.x.y'], 'a.*.*', ['a.b.c', 'a.x.y']),
             (['a.b', 'a.b.c', 'a.x.y'], 'a.{b,x}.*', ['a.b.c', 'a.x.y']),
             (['a.b', 'a.b.c', 'a.x.y'], 'a.{b,x}.{c,y}', ['a.b.c', 'a.x.y']),
-            (['a.b', 'a.b.c', 'a.x.y', 'a.x.z'], 'a.{b,x}.{c,{y,z}}', ['a.b.c', 'a.x.y', 'a.x.z']),
+            (['a.b', 'a.b.c', 'a.x.y', 'a.x.z'],
+             'a.{b,x}.{c,{y,z}}',
+             ['a.b.c', 'a.x.y', 'a.x.z']),
         ]
         for (full, glob, filtered) in scenarii:
             self.assertEqual(filtered, filter_metrics(full, glob))
+
+    def test_graphite_glob_parser(self):
+        scenarii = [
+            # Positive examples
+            ("a.b", [['a'], ['b']]),
+            ("a?b.c", [['a', bg_glob.AnyChar(), 'b'], ['c']]),
+            ("a.b*c", [['a'], ['b', bg_glob.AnySequence(), 'c']]),
+            ("a.b**c", [['a'], ['b'], bg_glob.Globstar(), ['c']]),
+            ("a.**.c", [['a'], bg_glob.Globstar(), ['c']]),
+            ("a.**", [['a'], bg_glob.Globstar()]),
+            ("a[xyz].b", [['a', bg_glob.AnyChar()], ['b']]),
+            ("a[!rat].b", [['a', bg_glob.AnyChar()], ['b']]),
+            ("pl[a-ox]p", [['pl', bg_glob.AnyChar(), 'p']]),
+            ("a[b-dopx-z]b.c", [['a', bg_glob.AnyChar(), 'b'], ['c']]),
+            ("b[i\\]m", [['b', bg_glob.AnyChar(), 'm']]),
+            ("a[x-xy]b", [['a', bg_glob.AnyChar(), 'b']]),
+            ("a[y-xz]b", [['a', bg_glob.AnyChar(), 'b']]),
+            ("a.b.{c,d}", [['a'], ['b'], [bg_glob.AnySequence()]]),
+            ("a.b.{c,d}-{e,f}",
+             [['a'], ['b'], [bg_glob.AnySequence(), '-', bg_glob.AnySequence()]]),
+            ("a.b.oh{c{d,e,}{a,b},f{g,h}i}ah",
+             [['a'], ['b'], ['oh', bg_glob.AnySequence(), 'ah']]),
+            ("a.b{some[abc], chars[!xyz]}c",
+             [['a'], ['b', bg_glob.AnySequence(), 'c']]),
+            # Negative examples
+            ("a[.b", [['a['], ['b']]),
+            ("a{.b", [['a{'], ['b']]),
+            ("a{.b.c}", [['a{'], ['b'], ['c}']]),
+            ("a.", [['a']]),
+            ("a..b", [['a'], ['b']]),
+        ]
+        parser = bg_glob.GraphiteGlobParser()
+        for (glob, expected) in scenarii:
+            parsed = parser.parse(glob)
+            self.assertSequenceEqual(expected, parsed)
 
 
 class TestGlobUtils(bg_test_utils.TestCaseWithFakeAccessor):


### PR DESCRIPTION
Initial work for #169 

Summary:
* Adds a (simplistic) graphite pattern parser to our glob utils that can be reused
* Makes use of said parser in the Cassandra driver implementation to take advantage of prefix queries (because we are currently using prefix SASI indexes) on metric name components whenever possible

Warning:
* This has been tested quickly, but not thoroughly benchmarked yet

Future work:
* Add brace selector parsing, and use it to generate several queries using the generated values whenever possible (e.g. a{b,c,d}.b would generate 3 queries, for ab.b / ac.b / ad.b, instead of “a%.b” + potentially costly post-filtering)
* Caveat: beware of situations with character selectors inside the brace selector! (-> naive implementation will not be correct!)

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/biggraphite/173)
<!-- Reviewable:end -->
