### PR TITLE
metadata_cache: fix LMDB stale reader issue

### DIFF
--- a/biggraphite/metadata_cache.py
+++ b/biggraphite/metadata_cache.py
@@ -311,6 +311,11 @@ class DiskCache(Cache):
             max_spare_txns=128,
         )
 
+        # Clean stale readers
+        # This can happen if a previous instance crashed or was killed abruptly
+        cleaned_stale_reader = self.__env.reader_check()
+        logging.info("%d stale readers cleared." % cleaned_stale_reader)
+
         databases = {}
         for name in self.__databases:
             databases[name] = self.__env.open_db(name)


### PR DESCRIPTION
- if a process crashed or was stopped abruptly, stale readers remain. So
we clean stale readers just after we open the database.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/biggraphite/202)
<!-- Reviewable:end -->
