### PR TITLE
Enable posargs in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,35 +15,22 @@
 envlist = {py27,pypy}-coverage,pylama
 
 [testenv]
-passenv=
-    CASSANDRA_HOME
-    JAVA_HOME
-setenv=
-    # Prevents graphite from trying to install itself in /opt/
-    GRAPHITE_NO_PREFIX=true
-
-
-[base-coverage]
-commands = coverage erase
-           coverage run \
-           --omit=biggraphite/test_utils.py \
-           -m unittest discover --failfast --verbose --catch
-           coverage report
+commands =
+         coverage erase
+         coverage run \
+         --omit=biggraphite/test_utils.py \
+         -m unittest {posargs:discover --catch --catch --failfast --verbose}
+         coverage report
 deps =
      coverage
      -r{toxinidir}/requirements.txt
      -r{toxinidir}/tests-requirements.txt
-
-
-[testenv:py27-coverage]
-commands={[base-coverage]commands}
-deps={[base-coverage]deps}
-
-
-[testenv:pypy-coverage]
-commands={[base-coverage]commands}
-deps={[base-coverage]deps}
-
+passenv =
+        CASSANDRA_HOME
+        JAVA_HOME
+setenv =
+       # Prevents graphite from trying to install itself in /opt/
+       GRAPHITE_NO_PREFIX=true
 
 [testenv:pylama]
 basepython = pypy


### PR DESCRIPTION
Makes fast iteration on tests less of a hassle (issue #179).

Sample use cases (same as non-discovery unittest):
   tox -- tests                                          # by module
   tox -- tests.test_glob_utils                          # by file
   tox -- tests.test_accessor.TestMetric                 # by test class
   tox -- tests.test_graphite.TestFinder.test_find_nodes # by test method

Unfortunately, due to the strange way unittest handles arguments (see its
usage text for details) it is not easy pass the usual arguments (catch,
failfast, verbose) in both the default and the posargs calls.

You can pass them through the posargs if you need them:
   tox -- -cfv tests.test_glob_utils.TestGlobUtils

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/biggraphite/209)
<!-- Reviewable:end -->
