### PR TITLE
If metadata is not set, return defaults values

### DIFF
--- a/biggraphite/accessor.py
+++ b/biggraphite/accessor.py
@@ -592,6 +592,9 @@ class MetricMetadata(object):
     @classmethod
     def from_string_dict(cls, d):
         """Turn a dict of string to string into a MetricMetadata."""
+        if d is None:
+            return cls()
+
         return cls(
             aggregator=Aggregator.from_config_name(d.get("aggregator")),
             retention=Retention.from_string(d.get("retention")),


### PR DESCRIPTION
when running repair I got this stack trace

```Feb 14 11:09:17 graphite-global-cache-bg01-am5 bgutil[55441]: Traceback (most recent call last):
Feb 14 11:09:17 graphite-global-cache-bg01-am5 bgutil[55441]: File "/opt/graphite/pypy/bin/bgutil", line 11, in <module>
Feb 14 11:09:17 graphite-global-cache-bg01-am5 bgutil[55441]: load_entry_point('biggraphite==0.7.0', 'console_scripts', 'bgutil')()
Feb 14 11:09:17 graphite-global-cache-bg01-am5 bgutil[55441]: File "/opt/graphite/pypy/site-packages/biggraphite/cli/bgutil.py", line 78, in main
Feb 14 11:09:17 graphite-global-cache-bg01-am5 bgutil[55441]: opts.func(accessor, opts)
Feb 14 11:09:17 graphite-global-cache-bg01-am5 bgutil[55441]: File "/opt/graphite/pypy/site-packages/biggraphite/cli/command_repair.py", line 82, in run
Feb 14 11:09:17 graphite-global-cache-bg01-am5 bgutil[55441]: end_key=opts.end_key)
Feb 14 11:09:17 graphite-global-cache-bg01-am5 bgutil[55441]: File "/opt/graphite/pypy/site-packages/biggraphite/metadata_cache.py", line 547, in repair
Feb 14 11:09:17 graphite-global-cache-bg01-am5 bgutil[55441]: metric = self._accessor.get_metric(key)
Feb 14 11:09:17 graphite-global-cache-bg01-am5 bgutil[55441]: File "/opt/graphite/pypy/site-packages/biggraphite/drivers/cassandra.py", line 1141, in get_metric
Feb 14 11:09:17 graphite-global-cache-bg01-am5 bgutil[55441]: metadata = bg_accessor.MetricMetadata.from_string_dict(config)
Feb 14 11:09:17 graphite-global-cache-bg01-am5 bgutil[55441]: File "/opt/graphite/pypy/site-packages/biggraphite/accessor.py", line 596, in from_string_dict
Feb 14 11:09:17 graphite-global-cache-bg01-am5 bgutil[55441]: aggregator=Aggregator.from_config_name(d.get("aggregator")),
Feb 14 11:09:17 graphite-global-cache-bg01-am5 bgutil[55441]: AttributeError: 'NoneType' object has no attribute 'get
```

This PR is aimed to fix that by returning defaults values for metadata is none is provided.

It should be interesting to understand how doe this happen in the first place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/biggraphite/247)
<!-- Reviewable:end -->
