### PR TITLE
Fix biggraphite install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
   global:
     - JAVA=false # Default
     ### As of 2016-04 Travis provides Cassandra 2.1 by default so we bundle our own
-    - CASSANDRA_VERSION=3.9
+    - CASSANDRA_VERSION=3.10
     - CASSANDRA_HOME="${TRAVIS_BUILD_DIR}/.deps/apache-cassandra-${CASSANDRA_VERSION}/"
   matrix:
     - TOXENV=pylama

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Commande line
 humanize
-ipython
+ipython<6
 parsedatetime
 progressbar2
 scandir


### PR DESCRIPTION
IPython6 need python>3.3, so we force ipython<5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/biggraphite/268)
<!-- Reviewable:end -->
