### PR TITLE
cassandra/carbon: make sure we change updated_on only for writes

### DIFF
--- a/biggraphite/accessor.py
+++ b/biggraphite/accessor.py
@@ -782,7 +782,7 @@ class Accessor(object):
         self._check_connected()
 
     @abc.abstractmethod
-    def get_metric(self, metric_name):
+    def get_metric(self, metric_name, touch=False):
         """Return a Metric for this metric_name, None if no such metric."""
         self._check_connected()
 

--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -1276,9 +1276,9 @@ class _CassandraAccessor(bg_accessor.Accessor):
         if (int(time.time()) - int(updated_on / 1000)) >= self.__metadata_touch_ttl_sec:
             self.touch_metric(metric_name)
 
-    def get_metric(self, metric_name):
+    def get_metric(self, metric_name, touch=False):
         """See bg_accessor.Accessor."""
-        super(_CassandraAccessor, self).get_metric(metric_name)
+        super(_CassandraAccessor, self).get_metric(metric_name, touch=touch)
         metric_name = ".".join(self._components_from_name(metric_name)[:-1])
         metric_name = bg_accessor.encode_metric_name(metric_name)
         result = self._select_metric(metric_name)
@@ -1292,7 +1292,9 @@ class _CassandraAccessor(bg_accessor.Accessor):
         if not result[0] or not result[1]:
             return None
 
-        self.__touch_metadata_on_need(metric_name, updated_on)
+        if touch:
+            self.__touch_metadata_on_need(metric_name, updated_on)
+
         metadata = bg_accessor.MetricMetadata.from_string_dict(config)
         return bg_accessor.Metric(metric_name, id, metadata)
 

--- a/biggraphite/drivers/memory.py
+++ b/biggraphite/drivers/memory.py
@@ -175,9 +175,9 @@ class _MemoryAccessor(bg_accessor.Accessor):
         super(_MemoryAccessor, self).has_metric(metric_name)
         return self.get_metric(metric_name) is not None
 
-    def get_metric(self, metric_name):
+    def get_metric(self, metric_name, touch=False):
         """See the real Accessor for a description."""
-        super(_MemoryAccessor, self).get_metric(metric_name)
+        super(_MemoryAccessor, self).get_metric(metric_name, touch=touch)
         metric_name = ".".join(self._components_from_name(metric_name))
         return self._name_to_metric.get(metric_name)
 

--- a/biggraphite/metadata_cache.py
+++ b/biggraphite/metadata_cache.py
@@ -128,7 +128,7 @@ class MetadataCache(object):
                 self._cache_set(metric_name, metric)
         return found
 
-    def get_metric(self, metric_name):
+    def get_metric(self, metric_name, touch=False):
         """Return a Metric for this metric_name, None if no such metric."""
         metric, hit = self._cache_get(metric_name)
         if hit:
@@ -138,7 +138,7 @@ class MetadataCache(object):
         # Check that is still doesn't exists.
         if not metric:
             with self._accessor_lock:
-                metric = self._accessor.get_metric(metric_name)
+                metric = self._accessor.get_metric(metric_name, touch=touch)
                 self._cache_set(metric_name, metric)
 
         return metric

--- a/biggraphite/plugins/carbon.py
+++ b/biggraphite/plugins/carbon.py
@@ -103,7 +103,7 @@ class BigGraphiteDatabase(database.TimeSeriesDatabase):
     @WRITE_TIME.time()
     def write(self, metric_name, datapoints):
         # Get a Metric object from metric name.
-        metric = self.cache.get_metric(metric_name=metric_name)
+        metric = self.cache.get_metric(metric_name=metric_name, touch=True)
         if not metric:
             raise Exception('Could not find %s' % (metric_name))
 

--- a/tests/test_cassandra.py
+++ b/tests/test_cassandra.py
@@ -428,7 +428,7 @@ class TestAccessorWithCassandra(bg_test_utils.TestCaseWithAccessor):
         self.accessor.touch_metric = touch_metric_moc
 
         time.sleep(3)
-        self.accessor.get_metric(metric1.name)
+        self.accessor.get_metric(metric1.name, touch=True)
         self.assertEquals(isUpdated[0], True)
 
         self.accessor.touch_metric = old_touch_fn
@@ -449,6 +449,9 @@ class TestAccessorWithCassandra(bg_test_utils.TestCaseWithAccessor):
 
         time.sleep(3)
         self.accessor.get_metric(metric1.name)
+        self.assertEquals(isUpdated[0], False)
+
+        self.accessor.get_metric(metric1.name, touch=True)
         self.assertEquals(isUpdated[0], False)
 
         self.accessor.touch_metric = old_touch_fn


### PR DESCRIPTION
It's easier to hikack get_metric() here than to store updated_on
in metadata, so we add another argument to get_metric()