### PR TITLE
bgutil syncdb: add a way to create datapoint tables

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -10,7 +10,9 @@ Configure Cassandra (you will probably want to tweak the keyspace).
 ```bash
 $ ${CASSANDRA_HOME}/bin/cqlsh < share/schema.cql
 # Can be slow on HDD. Restart-it if it timeouts.
-$ bgutil --cassandra_contact_points=localhost syncdb
+$ bgutil --cassandra_contact_points=localhost syncdb --storage-schemas storage-schemas.conf
+# To create arbitrary retentions and see the schema:
+$ bgutil --cassandra_contact_points=localhost syncdb --dry_run --retention "86400*1s:10080*60s" 
 ```
 
 ## Carbon plugin

--- a/biggraphite/accessor.py
+++ b/biggraphite/accessor.py
@@ -701,10 +701,11 @@ class Accessor(object):
         """
         pass
 
-    def syncdb(self, dry_run=False):
+    def syncdb(self, retentions=None, dry_run=False):
         """Create the database schema.
 
         Args:
+          retentions, iterable or None, list of retentions to create.
           dry_run: bool, if True nothing will be applied to the database.
         """
         pass

--- a/tests/test_cassandra.py
+++ b/tests/test_cassandra.py
@@ -507,6 +507,11 @@ class TestAccessorWithCassandra(bg_test_utils.TestCaseWithAccessor):
         self.assertEquals(self.accessor.has_metric(metric2.name), True)
         self.addCleanup(self.accessor.drop_all_metrics)
 
+    def test_syncdb(self):
+        retentions = [bg_accessor.Retention.from_string("60*1s:60*60s")]
+        self.accessor.syncdb(retentions=retentions, dry_run=True)
+        self.accessor.syncdb(retentions=retentions, dry_run=False)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_command_syncdb.py
+++ b/tests/test_command_syncdb.py
@@ -30,7 +30,9 @@ class TestCommandSyncdb(bg_test_utils.TestCaseWithFakeAccessor):
         parser = argparse.ArgumentParser()
         bg_utils.add_argparse_arguments(parser)
         cmd.add_arguments(parser)
-        opts = parser.parse_args([])
+        opts = parser.parse_args(['--retention', '86400*1s:10080*60s'])
+        cmd.run(self.accessor, opts)
+        opts = parser.parse_args(['--dry_run'])
         cmd.run(self.accessor, opts)
 
 

--- a/tests/test_command_write.py
+++ b/tests/test_command_write.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# Copyright 2016 Criteo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import print_function
+
+import unittest
+import argparse
+
+from biggraphite.cli import command_write
+from biggraphite import utils as bg_utils
+from biggraphite import test_utils as bg_test_utils
+
+
+class TestCommandWrite(bg_test_utils.TestCaseWithFakeAccessor):
+
+    def test_run(self):
+        cmd = command_write.CommandWrite()
+
+        parser = argparse.ArgumentParser()
+        bg_utils.add_argparse_arguments(parser)
+        cmd.add_arguments(parser)
+        opts = parser.parse_args(['metric', '1'])
+        cmd.run(self.accessor, opts)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This will make everything easier because Cassandra isn't really
happy when multiple carbon processes try to create new tables at the same time.