### PR TITLE
graphite: fix the find_nodes cache key

### DIFF
--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -1430,6 +1430,8 @@ class _CassandraAccessor(bg_accessor.Accessor):
             try:
                 for success, results in query_results:
                     query = results.response_future.query.query_string
+                    # Make sure we also cache empty results.
+                    fetched_results[query] = []
                     for result in results:
                         n_metrics += 1
                         name = result[0]
@@ -1440,7 +1442,7 @@ class _CassandraAccessor(bg_accessor.Accessor):
             except cassandra.DriverException as e:
                 raise CassandraError('Failed to glob: %s on %s' % (table, glob), e)
 
-            if self.cache:
+            if self.cache and fetched_results:
                 self.cache.set_many(fetched_results, timeout=self.cache_metadata_ttl)
 
         return _extract_results(query_results)

--- a/biggraphite/plugins/graphite.py
+++ b/biggraphite/plugins/graphite.py
@@ -265,15 +265,19 @@ class Finder(BaseFinder):
                 self._cache_timeout = django_settings.FIND_CACHE_DURATION
         return self._django_cache
 
+    def _hash(self, obj):
+        # Make sure we use all the member of the objects to
+        # build a unique key.
+        return hashing.compactHash(str(sorted(vars(obj).items())))
+
     def find_nodes(self, query):
         """Find nodes matching a query."""
         # TODO: we should probably consider query.startTime and query.endTime
         #  to filter out metrics that had no points in this interval.
-
         leaves_only = hasattr(query, 'leaves_only') and query.leaves_only
-        cache_key = "find_nodes:%s" % (hashing.compactHash(query.pattern))
+        cache_key = "find_nodes:%s" % self._hash(query)
         cached = self.django_cache().get(cache_key)
-        if cached:
+        if cached is not None:
             cache_hit = True
             success, results = cached
         else:


### PR DESCRIPTION
Before this patch, different queries would have the same cache
key because only the pattern would be used to differenciate queries.

Now we use all attributes.

This would mostly have an impact when leaves_only is set to True.