### PR TITLE
cassandra.py: fix _execute_data in syncdb

### DIFF
--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -1794,7 +1794,7 @@ class _CassandraAccessor(bg_accessor.Accessor):
                 query = self.__lazy_statements._create_datapoints_table_stmt(stage)
                 schema += query + "\n\n"
                 if not dry_run:
-                    self._execute_metadata(query)
+                    self._execute_data(query)
 
         self.shutdown()
         return schema


### PR DESCRIPTION
Signed-off-by: Jean-Francois Weber-Marx <jf.webermarx@criteo.com>
In biggraphite/drivers/cassandra.py in syndb it should be self._execute_data(query) instead of self._execute_metadata(query)