### PR TITLE
graphite: fix performance regressions with 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.10.2] - 2018-01-08
+
+### Fixed
+- Fixed performance regression with 1.1.0
+- Fixed some bugs caused by the Python 3 support
+
 ## [0.10.0] - 2017-12-20
 
 ### New
@@ -165,7 +171,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - We are going to do releases from now on
 
 
-[Unreleased]: https://github.com/criteo/biggraphite/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/criteo/biggraphite/compare/v0.10.2...HEAD
+[0.10.2]: https://github.com/criteo/biggraphite/compare/v0.10.1...v0.10.2
+[0.10.1]: https://github.com/criteo/biggraphite/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/criteo/biggraphite/compare/v0.9.2...v0.10.0
 [0.9.2]: https://github.com/criteo/biggraphite/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/criteo/biggraphite/compare/v0.9.0...v0.9.1

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,7 +1,12 @@
 # Usage
 
+First you need a working install of Graphite and Carbon: http://graphite.readthedocs.io/en/latest/install-virtualenv.html
+
 Start by installing biggraphite:
 ```bash
+$ # Last release version
+$ pip install biggraphite
+$ # From git
 $ pip install -U https://github.com/criteo/biggraphite/archive/master.zip
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,13 +22,5 @@ prometheus_client
 # Metadata cache
 lmdb
 
-# Graphite
-whisper
-carbon
-graphite-web
-
-# We could use Django<2.0 but we match what graphire requires instead.
-Django>=1.8,<1.11.99
-
-# Optional:
+# Optional, for bgutil shell:
 # ipython

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ _INSTALL_REQUIRES = [l for l in _REQUIREMENTS_TXT if "://" not in l]
 
 setuptools.setup(
     name="biggraphite",
-    version="0.10.1",
+    version="0.10.2",
     maintainer="Criteo Graphite Team",
     maintainer_email="github@criteo.com",
     description="Simple Scalable Time Series Database.",

--- a/tests-requirements.txt
+++ b/tests-requirements.txt
@@ -1,13 +1,26 @@
-django-tagging
+# Testing
 freezegun
 mock
-pytz
-testing.cassandra3
-twisted
-unittest2
-zope.interface
-pytest
-pytest-benchmark
 pygal<2.2
 pygaljs
+pytest
+pytest-benchmark
+unittest2
+
+# Cassandra
+testing.cassandra3
+
+# For bg-replay-traffic
 dpkt
+
+# Graphite and dependencies.
+graphite-web
+django-tagging
+pytz
+carbon
+twisted
+zope.interface
+whisper
+
+# We could use Django<2.0 but we match what graphire requires instead.
+Django>=1.8,<1.11.99


### PR DESCRIPTION
1.1.0 removed `FetchInProgress` so we need to re-implement
`fetch()` to keep the kind of performances that we had before.

I also noticed that `Reader.__refresh_metric()` could take up to
~40ms with Cassandra, which slow downs everything because this
happens *before* we build the generator. We need to fix that.