### PR TITLE
Fix listing of metrics & directories in CLI commands

### DIFF
--- a/biggraphite/cli/command_list.py
+++ b/biggraphite/cli/command_list.py
@@ -19,14 +19,19 @@ from __future__ import print_function
 from biggraphite.cli import command
 from biggraphite.glob_utils import graphite_glob
 
+
 def list_metrics(accessor, pattern):
-    """Return the list of metrics corresponding to pattern. Exit with error message if None.
+    """Return the list of metrics corresponding to pattern.
+    Exit with error message if None.
 
     Args:
         - accessor, Accessor, a connected accessor
         - pattern, string, e.g. my.metric.a or my.metric.**.a
     """
-    metrics_names = graphite_glob(accessor, pattern, metrics=True, directories=False)[0]
+    metrics_names = graphite_glob(accessor,
+                                  pattern,
+                                  metrics=True,
+                                  directories=False)[0]
     for metric in metrics_names:
         if metric is None:
             continue
@@ -55,9 +60,16 @@ class CommandList(command.BaseCommand):
         See command.CommandBase.
         """
         accessor.connect()
-        directories_names = graphite_glob(accessor, opts.glob, metrics=False, directories=True)[1]
+        directories_names = graphite_glob(
+            accessor,
+            opts.glob,
+            metrics=False,
+            directories=True
+            )[1]
         for directory in directories_names:
             print("d %s" % directory)
         for metric in list_metrics(accessor, opts.glob):
             if metric:
-                print("m %s %s" % (metric.name, metric.metadata.as_string_dict()))
+                print("m %s %s" % (
+                    metric.name,
+                    metric.metadata.as_string_dict()))

--- a/biggraphite/cli/command_list.py
+++ b/biggraphite/cli/command_list.py
@@ -17,7 +17,7 @@
 from __future__ import print_function
 
 from biggraphite.cli import command
-
+from biggraphite.glob_utils import graphite_glob
 
 def list_metrics(accessor, pattern):
     """Return the list of metrics corresponding to pattern. Exit with error message if None.
@@ -26,9 +26,8 @@ def list_metrics(accessor, pattern):
         - accessor, Accessor, a connected accessor
         - pattern, string, e.g. my.metric.a or my.metric.**.a
     """
-    metric_names = accessor.glob_metric_names(pattern)
-
-    for metric in metric_names:
+    metrics_names = graphite_glob(accessor, pattern, metrics=True, directories=False)[0]
+    for metric in metrics_names:
         if metric is None:
             continue
         yield accessor.get_metric(metric)
@@ -56,8 +55,8 @@ class CommandList(command.BaseCommand):
         See command.CommandBase.
         """
         accessor.connect()
-
-        for directory in accessor.glob_directory_names(opts.glob):
+        directories_names = graphite_glob(accessor, opts.glob, metrics=False, directories=True)[1]
+        for directory in directories_names:
             print("d %s" % directory)
         for metric in list_metrics(accessor, opts.glob):
             if metric:

--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -26,6 +26,7 @@ import os
 import random
 import time
 import uuid
+import six
 from os import path as os_path
 from distutils import version
 
@@ -45,6 +46,7 @@ from biggraphite.drivers import _downsampling
 from biggraphite.drivers import _delayed_writer
 from biggraphite.drivers import _utils
 from biggraphite.drivers import cassandra_policies as bg_cassandra_policies
+from biggraphite.drivers.lucene import cassandra_stratio
 
 import prometheus_client as pm
 
@@ -90,6 +92,10 @@ DEFAULT_MAX_BATCH_UTIL = 1000
 DEFAULT_TIMEOUT_QUERY_UTIL = 120
 DEFAULT_UPDATED_ON_TTL_SEC = 3 * DAY
 DEFAULT_READ_ON_SAMPLING_RATE = 0.1
+DEFAULT_USE_STRATIO = False
+
+USE_STRATIO = bool(os.environ.get('USE_STRATIO', DEFAULT_USE_STRATIO))
+STRATIO_INDEX_REFRESH_PERIOD_SECOND = 61 # Default value
 
 # Exceptions that are not considered fatal during batch jobs.
 # The affected range will simply be ignored.
@@ -412,6 +418,9 @@ _METADATA_CREATION_CQL = ([
     + _METADATA_CREATION_CQL_METRICS_METADATA_UPDATED_ON_INDEX
     + _METADATA_CREATION_CQL_METRICS_METADATA_READ_ON_INDEX
 )
+
+if USE_STRATIO:
+    _METADATA_CREATION_CQL += cassandra_stratio.CQL_CREATE_INDICES
 
 _DATAPOINTS_CREATION_CQL_TEMPLATE = str(
     "CREATE TABLE IF NOT EXISTS %(table)s ("
@@ -1401,7 +1410,10 @@ class _CassandraAccessor(bg_accessor.Accessor):
                 )
             )
 
-        if GLOBSTAR in components:
+        isFullyDefinedMetric = all(len(c) == 1 and isinstance(c[0],six.string_types) for c in components)
+        if USE_STRATIO and not isFullyDefinedMetric:
+            queries = [cassandra_stratio.generate_query(self.keyspace_metadata,table,glob,self.max_metrics_per_pattern)]
+        elif GLOBSTAR in components:
             queries = self.__generate_globstar_names_queries(table, components)
         else:
             components.append([_LAST_COMPONENT])

--- a/biggraphite/drivers/lucene/__init__.py
+++ b/biggraphite/drivers/lucene/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2016 Criteo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/biggraphite/drivers/lucene/cassandra_stratio.py
+++ b/biggraphite/drivers/lucene/cassandra_stratio.py
@@ -1,0 +1,36 @@
+import lucene
+import cassandra
+import os
+
+_COMPONENTS_INDEX_MAX_LEN = int(os.environ.get('BG_COMPONENTS_INDEX_MAX_LEN',os.environ.get('BG_COMPONENTS_MAX_LEN', 64)))
+
+_CQL_PATH_COMPONENTS_INDEX_FIELDS = ",\n".join(
+    "        component_%d : {type: \"string\"}" % n for n in range(_COMPONENTS_INDEX_MAX_LEN)
+)
+
+CQL_CREATE_INDICES = [
+    "CREATE CUSTOM INDEX IF NOT EXISTS %(table)s_idx ON \"%%(keyspace)s\".%(table)s()"
+    "  USING 'com.stratio.cassandra.lucene.Index' WITH OPTIONS = {"
+    "    'schema': '{"
+    "      fields: {"
+    "        parent : {type: \"string\"},"
+    "%(components)s"
+    "      }"
+    "    }'"
+    "  };"  % {"table": t, "components": _CQL_PATH_COMPONENTS_INDEX_FIELDS}
+    for t in ('metrics', 'directories')
+]
+
+_CQL_SELECT_NAME_SEARCH_QUERY = """SELECT name
+FROM {keyspace}.{table}
+WHERE expr({table}_idx, '{lucene_filter}')
+LIMIT {limit}"""
+
+
+def generate_query(keyspace, table, glob, max_metrics_per_pattern):
+    return _CQL_SELECT_NAME_SEARCH_QUERY.format(
+            keyspace=keyspace,
+            table=table,
+            lucene_filter=lucene.translate_glob_to_lucene_filter(glob),
+            limit=max_metrics_per_pattern
+            )

--- a/biggraphite/drivers/lucene/lucene.py
+++ b/biggraphite/drivers/lucene/lucene.py
@@ -1,0 +1,116 @@
+import six
+from biggraphite import glob_utils
+
+##########
+# Lucene #
+##########
+
+# Graphite Abstract Syntax Tree supported types
+GLOBSTAR = glob_utils.Globstar
+ANYSEQUENCE = glob_utils.AnySequence
+ANYCHAR = glob_utils.AnyChar
+VALUELIST = glob_utils.GlobExpressionWithValues
+STRING = six.string_types
+
+# Value stored in Cassandra columns component_? to mark the end of the metric name or pattern
+END_MARK = "__END__"
+
+LUCENE_FILTER = """{
+    filter: {
+        type: "boolean",
+        must: [
+            %s
+        ]
+    }
+}"""
+
+
+def translate_glob_to_lucene_filter(glob):
+    """Take graphite metrics glob syntax string as input.
+    Parse the glob syntax.
+    Build an equivalent Apache Lucene filter using hardcoded assumptions about the index schema.
+    Return an Lucene filter json string.
+    """
+    components = glob_utils.GraphiteGlobParser().parse(glob)
+    return translate_to_lucene_filter(components)
+
+
+def translate_to_lucene_filter(components):
+    """Take a glob components iterable.
+    Build an equivalent Apache Lucene filter using hardcoded assumptions about the index schema.
+    Return an Lucene filter json string.
+    """
+    if any(isinstance(x, GLOBSTAR) for x in components):
+        if isinstance(components[-1],GLOBSTAR):
+            # No define length: match on components before the GLOBSTAR
+            components.pop()
+            must_list = _build_filters(components)
+        else:
+            # GLOBSTAR is only supported at the end of a glob syntax
+            raise Exception("Metric pattern syntax only supports '%s' at the end") % GLOBSTAR
+    elif ( # Parent query
+        len(components) > 1
+        and
+        all(len(c) == 1 and isinstance(c[0],six.string_types) for c in components[:-1]) 
+        and 
+        isinstance(components[:-1],ANYSEQUENCE)
+        ):
+        parent = ""
+        for component in components:
+            parent += component[0] + "."
+        must_list.append("""{ field:"parent", type:"match", value:"%s" }""" % parent)
+    else:
+        must_list = _build_filters(components)
+        # Restric length by matching the END_MARK
+        must_list.append("""{ field:"%s", type:"match", value:"%s" }""" % (_component_name(len(components)),END_MARK))
+
+    return LUCENE_FILTER % ",\n\t\t".join(must_list)
+
+
+def _component_name(component_index):
+    return "component_%i" % component_index
+
+
+def _build_filters(components):
+    must_list = []
+    for idx, component in enumerate(components):
+        if len(component) == 0: 
+            raise Exception("Illegal glob component %s in glob %s" % (component,components))
+        elif len(component) == 1:
+            must_list.append(_build_simple_field_constrain(idx, component[0])) 
+        else: # len(component) > 1
+            # Lucene prefix, wildcard & regexp are 3 different syntax.
+            # Behavior and performances of underlying implementations are almost the same.
+            # We therefore only use the most expressive syntax: 'regexp'
+            must_list.append(_build_regex_field_constrain(idx,component))
+    return filter(None,must_list)
+
+
+def _build_simple_field_constrain(index, value):
+    if isinstance(value,ANYSEQUENCE):
+        return None # No constrain 
+    elif isinstance(value,STRING):
+        return """{ field:"%s", type:"match", value:"%s" }""" % (_component_name(index), value)
+    elif isinstance(value,VALUELIST):
+        return """{ field:"%s", type:"contains", values:["%s"] }""" % (_component_name(index), '","'.join(value.values))
+    elif isinstance(value,ANYCHAR):
+        return """{ field:"%s", type:"regexp", value:"." }""" % _component_name(index)
+    else:
+        raise Exception("Unhandled type '%s'" % value)
+
+
+def _build_regex_field_constrain(index, component):
+    regex = ""
+    for subcomponent in component:
+        if isinstance(subcomponent,ANYSEQUENCE):
+            regex += ".*"
+        elif isinstance(subcomponent,STRING):
+            regex += subcomponent
+        elif isinstance(subcomponent,VALUELIST):
+            regex += '('+'|'.join(subcomponent.values)+')'
+        elif isinstance(subcomponent,ANYCHAR):
+            # TODO: Fix AST so that AnyChar contains the actual alternatives (currently it discards the information)
+            regex += '.' # This is inexact, should be '[..]'
+        else:
+            raise Exception("Unhandled type '%s'" % subcomponent)
+    return """{ field:"%s", type:"regexp", value:"%s" }""" % (_component_name(index),regex)

--- a/biggraphite/test_utils.py
+++ b/biggraphite/test_utils.py
@@ -22,12 +22,12 @@ from __future__ import print_function
 
 import os
 import sys
+import time
 import tempfile
 import shutil
 import unittest
 import logging
 import uuid
-
 from cassandra import cluster as c_cluster
 import mock
 
@@ -35,7 +35,6 @@ from biggraphite import accessor as bg_accessor
 from biggraphite.drivers import cassandra as bg_cassandra
 from biggraphite.drivers import memory as bg_memory
 from biggraphite import metadata_cache as bg_metadata_cache
-
 
 HAS_CASSANDRA_HOME = bool(os.getenv("CASSANDRA_HOME"))
 
@@ -269,6 +268,63 @@ class TestCaseWithAccessor(TestCaseWithTempDir):
             self.accessor, {'path': self.tempdir, 'size': 1024 * 1024})
         self.metadata_cache.open()
         self.addCleanup(self.metadata_cache.close)
+        self._patch_accessor()
+
+
+    def _patch_accessor(self):
+        """Override accessor methods for tests
+        to enforce a statio index refresh between writes & reads call
+        """
+        if not bg_cassandra.USE_STRATIO:
+            return
+
+        ## Instead of sleeping I tried running:
+        # SELECT *
+        # FROM keyspace.metrics
+        # WHERE expr(metrics_idx, '{refresh:true}')
+        ## It did not work.
+        ## Adding "refresh:true" to lucene filter didn't work either.
+
+        orig_create_metric = self.accessor.create_metric
+        def _create_metric(metric):
+            self.last_create = time.time()
+            # print("create metric")
+            return orig_create_metric(metric)
+        self.accessor.create_metric = _create_metric
+
+        orig_select_metric = self.accessor._select_metric
+        def _select_metric(metric):
+            if hasattr(self, 'last_create'):
+                time_since_last_create = time.time() - self.last_create
+                time_to_sleep = bg_cassandra.STRATIO_INDEX_REFRESH_PERIOD_SECOND - time_since_last_create
+                # print("select_metric \t time_since_last_create %i, will sleep %i" % (time_since_last_create,time_to_sleep))
+                if time_to_sleep > 0:
+                    time.sleep(time_to_sleep)
+            return orig_select_metric(metric)
+        self.accessor._select_metric = _select_metric
+
+        orig_glob_metric_names = self.accessor.glob_metric_names
+        def _glob_metric_names(glob):
+            if hasattr(self, 'last_create'):
+                time_since_last_create = time.time() - self.last_create
+                time_to_sleep = bg_cassandra.STRATIO_INDEX_REFRESH_PERIOD_SECOND - time_since_last_create
+                # print("glob_metric_names \t time_since_last_create %i, will sleep %i" % (time_since_last_create,time_to_sleep))
+                if time_to_sleep > 0:
+                    time.sleep(time_to_sleep)
+            return orig_glob_metric_names(glob)
+        self.accessor.glob_metric_names = _glob_metric_names
+
+        orig_glob_directory_names = self.accessor.glob_directory_names
+        def _glob_directory_names(glob):
+            if hasattr(self, 'last_create'):
+                time_since_last_create = time.time() - self.last_create
+                time_to_sleep = bg_cassandra.STRATIO_INDEX_REFRESH_PERIOD_SECOND - time_since_last_create
+                # print("glob_directory_names \t time_since_last_create %i, will sleep %i" % (time_since_last_create,time_to_sleep))
+                if time_to_sleep > 0:
+                    time.sleep(time_to_sleep)
+            return orig_glob_directory_names(glob)
+        self.accessor.glob_directory_names = _glob_directory_names
+
 
     @classmethod
     def _reset_keyspace(cls, session, keyspace):


### PR DESCRIPTION
…) to list metrics & directories.

graphite_glob() post filter accessor.glob_metric_names() to ensure output correctness
This fix affect the behavior of 'read', 'du', 'copy' and 'list' commands.
A better but more involved fix would be to fix glob_metric_names() cassandra implementation and trust its output but some code might rely on the current behavior.