### PR TITLE
cassandra: do not call get_metric() each time we call fetch_points()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ matrix:
 env:
   global:
     - JAVA=false # Default
-    - CASSANDRA_VERSION=3.11.1
-    - CASSANDRA_STRATIO_LUCENE_VERSION=${CASSANDRA_VERSION}.0
+    - CASSANDRA_VERSION=3.11.2
+    - CASSANDRA_STRATIO_LUCENE_VERSION=3.11.1.0 #We should use ${CASSANDRA_VERSION}.0, but not released for 3.11.2 yet.
     - CASSANDRA_HOME="${TRAVIS_BUILD_DIR}/.deps/apache-cassandra-${CASSANDRA_VERSION}/"
 
 install:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ pip install -r tests-requirements.txt
 pip install -e .
 
 # Install Cassandra
-export CASSANDRA_VERSION=3.11.0
+export CASSANDRA_VERSION=3.11.2
 wget "http://www.us.apache.org/dist/cassandra/${CASSANDRA_VERSION}/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz"
 tar -xzf "apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz"
 export CASSANDRA_HOME=$(pwd)/apache-cassandra-${CASSANDRA_VERSION}


### PR DESCRIPTION
Also make sure we deal with metrics with empty id, config (those would
be created by calls to fetch_points() for non-existing metrics).

Also bump Cassandra to 3.11.2 for tests.