### PR TITLE
elasticsearch: basic support to create metrics

### DIFF
--- a/biggraphite/cli/bgutil.py
+++ b/biggraphite/cli/bgutil.py
@@ -82,6 +82,9 @@ def main(args=None, accessor=None):
         args = sys.argv[1:]
 
     opts = _parse_opts(args)
+    if not getattr(opts, "func", None):
+        opts.func = command_shell.CommandShell().run
+
     settings = bg_utils.settings_from_args(opts)
     bg_utils.set_log_level(settings)
     accessor = accessor or bg_utils.accessor_from_settings(settings)

--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -1542,7 +1542,8 @@ class _CassandraAccessor(bg_accessor.Accessor):
         """Flush any internal buffers."""
         if self.__delayed_writer:
             self.__delayed_writer.flush()
-        self.__lazy_statements.flush()
+        if self.__lazy_statements:
+            self.__lazy_statements.flush()
 
     def clear(self):
         """Clear all internal data."""


### PR DESCRIPTION
- Add support for labels in the import-elasticsearch scripts (for tests)
- Implement create_metric() in elasticsearch.py (very basic implementation)
- Add code the create missing indices when necessary (+ basic mapping)