### PR TITLE
Rename length to depth to bring clarity

### DIFF
--- a/biggraphite/drivers/elasticsearch.py
+++ b/biggraphite/drivers/elasticsearch.py
@@ -76,7 +76,7 @@ INDEX_SETTINGS = {
     "mappings": {
         "_doc": {
             "properties": {
-                "length": {"type": "long"},
+                "depth": {"type": "long"},
                 "created_on": {"type": "date"},
                 "read_on": {"type": "date"},
                 "updated_on": {"type": "date"},
@@ -183,7 +183,7 @@ def document_from_metric(metric):
     name = ".".join(components)  # We do that to avoid double dots.
 
     data = {
-        "length": len(components),
+        "depth": len(components) - 1,
         "name": name,
     }
 

--- a/tools/elasticsearch/import-metrics.py
+++ b/tools/elasticsearch/import-metrics.py
@@ -27,7 +27,7 @@ INDEX_BODY_METRICS = {
     "mappings": {
         "metric": {
             "properties": {
-                "length": {"type": "long"},
+                "depth": {"type": "long"},
                 "created_on": {"type": "date"},
                 "read_on": {"type": "date"},
                 "updated_on": {"type": "date"},
@@ -72,7 +72,7 @@ INDEX_BODY_DIRECTORIES = {
     "mappings": {
         "directory": {
             "properties": {
-                "length": {"type": "long"},
+                "depth": {"type": "long"},
                 "name": {
                     "type": "keyword",
                     "ignore_above": 1024,
@@ -107,7 +107,7 @@ def uuid_to_datetime(u):
 
 def document_base(name):
     data = {
-        "length": name.count("."),
+        "depth": name.count("."),
         "name": name,
     }
 


### PR DESCRIPTION
Today, the length is not accurate as a.b would have a length of 1
However, renaming length to depth would be clearer (a.b would have a depth of 1)
