### PR TITLE
Rename TestCaseWithAccessor to TestCaseWithCassandraAccessor

### DIFF
--- a/benchmarks/accessor_bench.py
+++ b/benchmarks/accessor_bench.py
@@ -13,7 +13,7 @@ from biggraphite.drivers import cassandra as bg_cassandra
 
 
 if bool(os.getenv("CASSANDRA_HOME")):
-    BASE_CLASS = bg_test_utils.TestCaseWithAccessor
+    BASE_CLASS = bg_test_utils.TestCaseWithCassandraAccessor
     ROUNDS = 100
     ROUNDS_LARGE = 10
     ITERATIONS = 10

--- a/biggraphite/test_utils.py
+++ b/biggraphite/test_utils.py
@@ -207,7 +207,7 @@ class TestCaseWithFakeAccessor(TestCaseWithTempDir):
 @unittest.skipUnless(
     HAS_CASSANDRA, "CASSANDRA_HOME must be set to a >=3.5 install",
 )
-class TestCaseWithAccessor(TestCaseWithTempDir):
+class TestCaseWithCassandraAccessor(TestCaseWithTempDir):
     """A TestCase with an Accessor for an ephemeral Cassandra cluster."""
 
     KEYSPACE = "testkeyspace"
@@ -217,7 +217,7 @@ class TestCaseWithAccessor(TestCaseWithTempDir):
     @classmethod
     def setUpClass(cls):
         """Create the test Cassandra Cluster as cls.cassandra."""
-        super(TestCaseWithAccessor, cls).setUpClass()
+        super(TestCaseWithCassandraAccessor, cls).setUpClass()
 
         cls.cassandra = None
         if CASSANDRA_HOSTPORT:
@@ -270,7 +270,7 @@ class TestCaseWithAccessor(TestCaseWithTempDir):
     @classmethod
     def tearDownClass(cls):
         """Stop the test Cassandra Cluster."""
-        super(TestCaseWithAccessor, cls).tearDownClass()
+        super(TestCaseWithCassandraAccessor, cls).tearDownClass()
         cls.accessor.shutdown()
         cls.cluster.shutdown()
         cls.session = None
@@ -281,14 +281,14 @@ class TestCaseWithAccessor(TestCaseWithTempDir):
 
     def setUp(self):
         """Create a new Accessor in self.acessor."""
-        super(TestCaseWithAccessor, self).setUp()
+        super(TestCaseWithCassandraAccessor, self).setUp()
         self.metadata_cache = self.CACHE_CLASS(
             self.accessor, {'path': self.tempdir, 'size': 1024 * 1024})
         self.metadata_cache.open()
 
     def tearDown(self):
         """Cleanup after tests."""
-        super(TestCaseWithAccessor, self).tearDown()
+        super(TestCaseWithCassandraAccessor, self).tearDown()
         self.metadata_cache.close()
         self.accessor.flush()
         self.accessor.clear()

--- a/tests/test_cassandra.py
+++ b/tests/test_cassandra.py
@@ -402,16 +402,16 @@ class _BaseTestAccessorWithCassandraMetadata(object):
 
 
 class TestAccessorWithCassandraSASI(_BaseTestAccessorWithCassandraMetadata,
-                                    bg_test_utils.TestCaseWithAccessor):
+                                    bg_test_utils.TestCaseWithCassandraAccessor):
     pass
 
 
 class TestAccessorWithCassandraLucene(_BaseTestAccessorWithCassandraMetadata,
-                                      bg_test_utils.TestCaseWithAccessor):
+                                      bg_test_utils.TestCaseWithCassandraAccessor):
     ACCESSOR_SETTINGS = {'use_lucene': True}
 
 
-class TestAccessorWithCassandraData(bg_test_utils.TestCaseWithAccessor):
+class TestAccessorWithCassandraData(bg_test_utils.TestCaseWithCassandraAccessor):
 
     def fetch(self, metric, *args, **kwargs):
         """Helper to fetch points as a list."""

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# Copyright 2016 Criteo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import print_function
+
+import unittest
+import time
+import re
+
+from distutils import version
+
+from biggraphite import accessor as bg_accessor
+from biggraphite import accessor_cache as bg_accessor_cache
+from biggraphite import test_utils as bg_test_utils
+from biggraphite import glob_utils as bg_glob_utils
+from biggraphite.drivers import elasticsearch as bg_elasticsearch
+
+
+class ElasticSearchAccessorTest(unittest.TestCase):
+
+    def test_components_from_name_should_create_array_by_splitting_on_dots(self):
+        expected = ['a', 'b', 'c', 'd']
+        result = bg_elasticsearch._components_from_name("a.b.c.d")
+        self.assertEqual(result, expected)
+
+    def test_components_from_name_should_ignore_double_dots(self):
+        expected = ['a', 'b', 'c']
+        result = bg_elasticsearch._components_from_name("a.b..c")
+        self.assertEqual(result, expected)
+
+    def test_components_from_name_should_handle_empty_strings(self):
+        expected = []
+        result = bg_elasticsearch._components_from_name("")
+        self.assertEqual(result, expected)
+
+    def test_document_from_metric_should_fail_on_None_metric(self):
+        with self.assertRaises(AttributeError) as context:
+            bg_elasticsearch.document_from_metric(None)
+        self.assertTrue("object has no attribute" in context.exception.message)


### PR DESCRIPTION
This test-case base class is dedicated to Cassandra and would be
misleading when starting writing tests for Elasticsearch accessor.
