### PR TITLE
ES: remove "keyword" in p*s queries

### DIFF
--- a/biggraphite/drivers/elasticsearch.py
+++ b/biggraphite/drivers/elasticsearch.py
@@ -556,7 +556,7 @@ class _ElasticSearchAccessor(bg_accessor.Accessor):
         search = search.filter('range', depth={'gte': glob_depth + 1})
         search = search.extra(from_=0, size=0)  # Do not return metrics.
 
-        search.aggs.bucket('distinct_dirs', 'terms', field="p%d.keyword" % glob_depth)
+        search.aggs.bucket('distinct_dirs', 'terms', field="p%d" % glob_depth)
 
         log.debug(json.dumps(search.to_dict()))
         response = search.execute()


### PR DESCRIPTION
`p0`... `px` are already keywords in the index mapping (see #354 / 02690897ece6ec9f4f9d3f6b4888267948d94795). 
They should be removed from the query.
