### PR TITLE
ES: remove keyword in p*s queries

### DIFF
--- a/biggraphite/drivers/elasticsearch.py
+++ b/biggraphite/drivers/elasticsearch.py
@@ -517,7 +517,7 @@ class _ElasticSearchAccessor(bg_accessor.Accessor):
                 filter_type, value = parse_complex_component(c)
 
             if filter_type:
-                search = search.filter(filter_type, **{"p%d.keyword" % i: value})
+                search = search.filter(filter_type, **{"p%d" % i: value})
         return False, search
 
     def glob_metric_names(self, glob):


### PR DESCRIPTION
p0... px are already keywords in the index mapping (see #354 /
0269089). They should be removed from
the query.

Same as #360 but on a forgotten case... 