### PR TITLE
ES: fix regexp in value sequence

### DIFF
--- a/biggraphite/drivers/elasticsearch.py
+++ b/biggraphite/drivers/elasticsearch.py
@@ -271,6 +271,10 @@ def parse_complex_component(component):
     return 'regexp', _parse_regexp_component(component)
 
 
+def _contains_regexp_wildcard(values):
+    return any("*" in value for value in values)
+
+
 def parse_simple_component(component):
     """Given a component with a simple type, this builds a constraint."""
     value = component[0]
@@ -283,7 +287,10 @@ def parse_simple_component(component):
     elif isinstance(value, bg_glob.CharIn):
         return 'regexp', '[' + ''.join(value.values) + ']'
     elif isinstance(value, bg_glob.SequenceIn):
-        return 'terms', value.values
+        if _contains_regexp_wildcard(value.values):
+            return 'regexp', '(' + '|'.join(value.values) + ')'
+        else:
+            return 'terms', value.values
     elif isinstance(value, bg_glob.AnyChar):
         return 'wildcard', '?'
     else:

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -127,11 +127,18 @@ class ParseSimpleComponentTest(unittest.TestCase):
             ('regexp', "[ab]")
         )
 
-    def test_SequenceIn_should_have_terms_constraint(self):
+    def test_SequenceIn_should_have_terms_constraint_when_there_are_no_regexp_in_terms(self):
         values = ["a", "b"]
         self.assertEqual(
             bg_elasticsearch.parse_simple_component([bg_glob.SequenceIn(values)]),
             ('terms', values)
+        )
+
+    def test_SequenceIn_should_have_regexp_constraint_when_there_are_regexp_in_terms(self):
+        values = ["a", "b*"]
+        self.assertEqual(
+            bg_elasticsearch.parse_simple_component([bg_glob.SequenceIn(values)]),
+            ('regexp', "(a|b*)")
         )
 
     def test_AnyChar_should_have_wildcard_constraint(self):


### PR DESCRIPTION
Example:

    foo.bar.{baz,qux*}

was not returning the correct result: a 'terms' query did not
match the regexp.

This case is now handled.
