### PR TITLE
Provide hybrid accessor

### DIFF
--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -802,7 +802,7 @@ class _CassandraAccessor(bg_accessor.Accessor):
     _UUID_NAMESPACE = uuid.UUID('{00000000-1111-2222-3333-444444444444}')
 
     def __init__(self,
-                 keyspace='biggraphite',
+                 keyspace=DEFAULT_KEYSPACE,
                  username=None,
                  password=None,
                  contact_points=DEFAULT_CONTACT_POINTS,

--- a/biggraphite/drivers/elasticsearch.py
+++ b/biggraphite/drivers/elasticsearch.py
@@ -136,6 +136,8 @@ OPTIONS = {
     "timeout": float,
 }
 
+UNDEFINED_RESULT = None
+
 
 def add_argparse_arguments(parser):
     """Add ElasticSearch arguments to an argparse parser."""
@@ -643,7 +645,7 @@ class _ElasticSearchAccessor(bg_accessor.Accessor):
         super(_ElasticSearchAccessor, self).fetch_points(
             metric, time_start, time_end, stage
         )
-        _raise_unsupported()
+        return UNDEFINED_RESULT
 
     def touch_metric(self, metric_name):
         """See the real Accessor for a description."""

--- a/biggraphite/drivers/hybrid.py
+++ b/biggraphite/drivers/hybrid.py
@@ -1,0 +1,151 @@
+# Copyright 2018 Criteo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Hybrid accessor, using one for metadata and one for data."""
+
+from biggraphite import accessor as bg_accessor
+
+
+class HybridAccessor(bg_accessor.Accessor):
+    """Hybrid accessor, using one for metadata and one for data."""
+
+    def __init__(self, backend_name, metadata_accessor, data_accessor):
+        """See the real Accessor for a description."""
+        super(HybridAccessor, self).__init__(backend_name)
+        self._metadata_accessor = metadata_accessor
+        self._data_accessor = data_accessor
+
+    def connect(self):
+        """See the real Accessor for a description."""
+        super(HybridAccessor, self).connect()
+        self._metadata_accessor.connect()
+        self._data_accessor.connect()
+        self.is_connected = True
+
+    def create_metric(self, metric):
+        """See the real Accessor for a description."""
+        super(HybridAccessor, self).create_metric(metric)
+        self._metadata_accessor.create_metric(metric)
+
+    def update_metric(self, name, updated_metadata):
+        """See the real Accessor for a description."""
+        super(HybridAccessor, self).update_metric(name, updated_metadata)
+        self._metadata_accessor.update_metric(name, updated_metadata)
+
+    def delete_metric(self, name):
+        """See the real Accessor for a description."""
+        super(HybridAccessor, self).delete_metric(name)
+        self._metadata_accessor.delete_metric(name)
+
+    def delete_directory(self, name):
+        """See the real Accessor for a description."""
+        super(HybridAccessor, self).delete_directory(name)
+        self._metadata_accessor.delete_directory(name)
+
+    def drop_all_metrics(self):
+        """See the real Accessor for a description."""
+        super(HybridAccessor, self).drop_all_metrics()
+        self._metadata_accessor.drop_all_metrics()
+        self._data_accessor.drop_all_metrics()
+
+    def fetch_points(self, metric, time_start, time_end, stage, aggregated=True):
+        """See the real Accessor for a description."""
+        super(HybridAccessor, self).fetch_points(metric, time_start, time_end, stage, aggregated)
+        self._metadata_accessor.fetch_points(metric, time_start, time_end, stage, aggregated)
+        return self._data_accessor.fetch_points(metric, time_start, time_end, stage, aggregated)
+
+    def has_metric(self, metric_name):
+        """See the real Accessor for a description."""
+        super(HybridAccessor, self).has_metric(metric_name)
+        return self._metadata_accessor.has_metric(metric_name)
+
+    def get_metric(self, metric_name, touch=False):
+        """See the real Accessor for a description."""
+        super(HybridAccessor, self).get_metric(metric_name, touch)
+        return self._metadata_accessor.get_metric(metric_name, touch)
+
+    def make_metric(self, name, metadata, created_on=None, updated_on=None, read_on=None):
+        """See the real Accessor for a description."""
+        super(HybridAccessor, self).make_metric(name, metadata, created_on, updated_on, read_on)
+        # we chose to call metadata accessor method but it should be moved up the accessor class
+        return self._metadata_accessor.make_metric(name, metadata, created_on, updated_on, read_on)
+
+    def glob_metric_names(self, glob):
+        """See the real Accessor for a description."""
+        super(HybridAccessor, self).glob_metric_names(glob)
+        return self._metadata_accessor.glob_metric_names(glob)
+
+    def glob_directory_names(self, glob):
+        """See the real Accessor for a description."""
+        super(HybridAccessor, self).glob_directory_names(glob)
+        return self._metadata_accessor.glob_directory_names(glob)
+
+    def background(self):
+        """See the real Accessor for a description."""
+        super(HybridAccessor, self).background()
+        self._metadata_accessor.background()
+        self._data_accessor.background()
+
+    def flush(self):
+        """See the real Accessor for a description."""
+        super(HybridAccessor, self).flush()
+        self._metadata_accessor.flush()
+        self._data_accessor.flush()
+
+    def clear(self):
+        """See the real Accessor for a description."""
+        super(HybridAccessor, self).clear()
+        self._metadata_accessor.clear()
+        self._data_accessor.clear()
+
+    def insert_points_async(self, metric, datapoints, on_done=None):
+        """See the real Accessor for a description."""
+        super(HybridAccessor, self).insert_points_async(metric, datapoints, on_done)
+        # Updating metadata here would be too expensive
+        self._data_accessor.insert_points_async(metric, datapoints, on_done)
+
+    def insert_downsampled_points_async(self, metric, datapoints, on_done=None):
+        """See the real Accessor for a description."""
+        super(HybridAccessor, self).insert_downsampled_points_async(metric, datapoints, on_done)
+        # Updating metadata here would be too expensive
+        self._data_accessor.insert_downsampled_points_async(metric, datapoints, on_done)
+
+    def map(self, callback, start_key=None, end_key=None, shard=0, nshards=1, errback=None):
+        """See the real Accessor for a description."""
+        super(HybridAccessor, self).map(callback, start_key, end_key, shard, nshards, errback)
+        return self._metadata_accessor.map(callback, start_key, end_key, shard, nshards, errback)
+
+    def repair(self, start_key=None, end_key=None, shard=0, nshards=1, callback_on_progress=None):
+        """See the real Accessor for a description."""
+        super(HybridAccessor, self).repair(start_key, end_key, shard, nshards,
+                                           callback_on_progress)
+        self._metadata_accessor.repair(start_key, end_key, shard, nshards, callback_on_progress)
+
+    def shutdown(self):
+        """See the real Accessor for a description."""
+        super(HybridAccessor, self).shutdown()
+        self._metadata_accessor.shutdown()
+        self._data_accessor.shutdown()
+
+    def touch_metric(self, metric_name):
+        """See the real Accessor for a description."""
+        super(HybridAccessor, self).touch_metric(metric_name)
+        self._metadata_accessor.touch_metric(metric_name)
+
+    def clean(self, max_age=None, start_key=None, end_key=None, shard=1, nshards=0,
+              callback_on_progress=None):
+        """See the real Accessor for a description."""
+        super(HybridAccessor, self).clean(max_age, start_key, end_key, shard, nshards,
+                                          callback_on_progress)
+        self._metadata_accessor.clean(max_age, start_key, end_key, shard, nshards,
+                                      callback_on_progress)

--- a/biggraphite/utils.py
+++ b/biggraphite/utils.py
@@ -24,6 +24,7 @@ from biggraphite.drivers import elasticsearch as bg_elasticsearch
 from biggraphite.drivers import memory as bg_memory
 from biggraphite import metadata_cache
 
+log = logging.getLogger(__name__)
 
 DRIVERS = frozenset([
     ("cassandra", bg_cassandra),

--- a/tests/drivers/test_hybrid.py
+++ b/tests/drivers/test_hybrid.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+# coding=utf-8
+# Copyright 2018 Criteo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from mock import Mock
+
+from biggraphite import accessor as bg_accessor
+from biggraphite.drivers import hybrid
+
+DEFAULT_METRIC_NAME = "foo.bar"
+DEFAULT_METADATA = bg_accessor.MetricMetadata()
+DEFAULT_METRIC = bg_accessor.Metric(DEFAULT_METRIC_NAME, "id", DEFAULT_METADATA)
+
+DEFAULT_GLOB = "foo.bar.**"
+
+
+class TestHybridAccessor(unittest.TestCase):
+
+    def setUp(self):
+        self._metadata_accessor = Mock()
+        self._data_accessor = Mock()
+        self._accessor = hybrid.HybridAccessor(
+            "test_hybrid",
+            self._metadata_accessor,
+            self._data_accessor
+        )
+
+    def test_connect_should_be_called_on_both_accessors(self):
+        self._accessor.connect()
+
+        self._metadata_accessor.connect.assert_called_once()
+        self._data_accessor.connect.assert_called_once()
+
+    def test_create_metric_should_be_called_only_for_metadata(self):
+        self._accessor.connect()
+        self._accessor.create_metric(DEFAULT_METRIC)
+
+        self._metadata_accessor.create_metric.assert_called_with(DEFAULT_METRIC)
+        self._data_accessor.create_metric.assert_not_called()
+
+    def test_update_metric_should_be_called_only_for_metadata(self):
+        self._accessor.connect()
+        self._accessor.update_metric(DEFAULT_METRIC, DEFAULT_METADATA)
+
+        self._metadata_accessor.update_metric.assert_called_with(DEFAULT_METRIC, DEFAULT_METADATA)
+        self._data_accessor.update_metric.assert_not_called()
+
+    def test_delete_metric_should_be_called_only_for_metadata(self):
+        self._accessor.connect()
+        self._accessor.delete_metric(DEFAULT_METRIC)
+
+        self._metadata_accessor.delete_metric.assert_called_with(DEFAULT_METRIC)
+        self._data_accessor.delete_metric.assert_not_called()
+
+    def test_delete_directory_should_be_called_only_for_metadata(self):
+        self._accessor.connect()
+        self._accessor.delete_directory(DEFAULT_METRIC_NAME)
+
+        self._metadata_accessor.delete_directory.assert_called_with(DEFAULT_METRIC_NAME)
+        self._data_accessor.delete_directory.assert_not_called()
+
+    def test_drop_all_metrics_should_be_called_on_both_accessors(self):
+        self._accessor.connect()
+        self._accessor.drop_all_metrics()
+
+        self._metadata_accessor.drop_all_metrics.assert_called_once()
+        self._data_accessor.drop_all_metrics.assert_called_once()
+
+    def test_fetch_points_should_be_called_on_both_accessors(self):
+        time_start = 0
+        time_end = 1
+        stage = bg_accessor.Stage("0", "1")
+        aggregated = False
+
+        self._accessor.connect()
+        self._accessor.fetch_points(DEFAULT_METRIC, time_start, time_end, stage, aggregated)
+
+        self._metadata_accessor.fetch_points.assert_called_with(
+            DEFAULT_METRIC, time_start, time_end, stage, aggregated
+        )
+        self._data_accessor.fetch_points.assert_called_with(
+            DEFAULT_METRIC, time_start, time_end, stage, aggregated
+        )
+
+    def test_has_metric_should_be_called_only_for_metadata(self):
+        self._accessor.connect()
+        self._accessor.has_metric(DEFAULT_METRIC_NAME)
+
+        self._metadata_accessor.has_metric.assert_called_with(DEFAULT_METRIC_NAME)
+        self._data_accessor.has_metric.assert_not_called()
+
+    def test_get_metric_should_be_called_only_for_metadata(self):
+        self._accessor.connect()
+        self._accessor.get_metric(DEFAULT_METRIC_NAME)
+
+        self._metadata_accessor.get_metric.assert_called_with(DEFAULT_METRIC_NAME, False)
+        self._data_accessor.get_metric.assert_not_called()
+
+    def test_make_metric_should_be_called_only_for_metadata(self):
+        self._accessor.connect()
+        self._accessor.make_metric(DEFAULT_METRIC_NAME, DEFAULT_METADATA)
+
+        self._metadata_accessor.make_metric.assert_called_with(
+            DEFAULT_METRIC_NAME, DEFAULT_METADATA, None, None, None
+        )
+        self._data_accessor.make_metric.assert_not_called()
+
+    def test_glob_metric_names_should_be_called_only_for_metadata(self):
+        self._accessor.connect()
+        self._accessor.glob_metric_names(DEFAULT_GLOB)
+
+        self._metadata_accessor.glob_metric_names.assert_called_with(DEFAULT_GLOB)
+        self._data_accessor.glob_metric_names.assert_not_called()
+
+    def test_glob_directory_names_should_be_called_only_for_metadata(self):
+        self._accessor.connect()
+        self._accessor.glob_directory_names(DEFAULT_GLOB)
+
+        self._metadata_accessor.glob_directory_names.assert_called_with(DEFAULT_GLOB)
+        self._data_accessor.glob_directory_names.assert_not_called()
+
+    def test_background_should_be_called_on_both_accessors(self):
+        self._accessor.connect()
+        self._accessor.background()
+
+        self._metadata_accessor.background.assert_called_once()
+        self._data_accessor.background.assert_called_once()
+
+    def test_flush_should_be_called_on_both_accessors(self):
+        self._accessor.connect()
+        self._accessor.flush()
+
+        self._metadata_accessor.flush.assert_called_once()
+        self._data_accessor.flush.assert_called_once()
+
+    def test_insert_points_async_should_be_called_only_on_data_accessor(self):
+        datapoints = []
+        self._accessor.connect()
+        self._accessor.insert_points_async(DEFAULT_METRIC, datapoints)
+
+        self._metadata_accessor.insert_points_async.assert_not_called()
+        self._data_accessor.insert_points_async.assert_called_with(DEFAULT_METRIC, datapoints, None)
+
+    def test_insert_downsampled_points_async_should_be_called_only_on_data_accessor(self):
+        datapoints = []
+        self._accessor.connect()
+        self._accessor.insert_downsampled_points_async(DEFAULT_METRIC, datapoints)
+
+        self._metadata_accessor.insert_downsampled_points_async.assert_not_called()
+        self._data_accessor.insert_downsampled_points_async.assert_called_with(
+            DEFAULT_METRIC, datapoints, None
+        )
+
+    def test_map_should_be_called_only_for_metadata(self):
+        def callback():
+            pass
+
+        self._accessor.connect()
+        self._accessor.map(callback)
+
+        self._metadata_accessor.map.assert_called_with(callback, None, None, 0, 1, None)
+        self._data_accessor.map.assert_not_called()
+
+    def test_repair_should_be_called_only_for_metadata(self):
+        self._accessor.connect()
+        self._accessor.repair()
+
+        self._metadata_accessor.repair.assert_called_with(None, None, 0, 1, None)
+        self._data_accessor.repair.assert_not_called()
+
+    def test_shutdown_should_be_called_on_both_accessors(self):
+        self._accessor.connect()
+        self._accessor.shutdown()
+
+        self._metadata_accessor.shutdown.assert_called_once()
+        self._data_accessor.shutdown.assert_called_once()
+
+    def test_touch_metric_should_be_called_only_for_metadata(self):
+        self._accessor.connect()
+        self._accessor.touch_metric(DEFAULT_METRIC_NAME)
+
+        self._metadata_accessor.touch_metric.assert_called_with(DEFAULT_METRIC_NAME)
+        self._data_accessor.touch_metric.assert_not_called()
+
+    def test_clean_should_be_called_only_for_metadata(self):
+        self._accessor.connect()
+        self._accessor.clean()
+
+        self._metadata_accessor.clean.assert_called_with(None, None, None, 1, 0, None)
+        self._data_accessor.clean.assert_not_called()


### PR DESCRIPTION
Allow to have separate accessors for metadata and data.

* When `driver` flag is provided, build a regular accessor
* When `data_driver` and `metadata_driver` flags are provided, build a composite accessor