### PR TITLE
Refactoring: remove touch attribute from get_metric

### DIFF
--- a/biggraphite/accessor.py
+++ b/biggraphite/accessor.py
@@ -853,7 +853,7 @@ class Accessor(object):
         self._check_connected()
 
     @abc.abstractmethod
-    def get_metric(self, metric_name, touch=False):
+    def get_metric(self, metric_name):
         """Return a Metric for this metric_name, None if no such metric."""
         self._check_connected()
 
@@ -929,6 +929,7 @@ class Accessor(object):
         if not isinstance(metric, Metric):
             raise InvalidArgumentError("%s is not a Metric instance" % metric)
         self._check_connected()
+        self.touch_metric(metric)
 
     def insert_downsampled_points(self, metric, datapoints):
         """Insert points for a given metric.
@@ -1010,7 +1011,7 @@ class Accessor(object):
         pass
 
     @abc.abstractmethod
-    def touch_metric(self, metric_name):
+    def touch_metric(self, metric):
         """Update a metric to refresh its last write timestamp."""
         self._check_connected()
 

--- a/biggraphite/drivers/hybrid.py
+++ b/biggraphite/drivers/hybrid.py
@@ -69,10 +69,10 @@ class HybridAccessor(bg_accessor.Accessor):
         super(HybridAccessor, self).has_metric(metric_name)
         return self._metadata_accessor.has_metric(metric_name)
 
-    def get_metric(self, metric_name, touch=False):
+    def get_metric(self, metric_name):
         """See the real Accessor for a description."""
-        super(HybridAccessor, self).get_metric(metric_name, touch)
-        return self._metadata_accessor.get_metric(metric_name, touch)
+        super(HybridAccessor, self).get_metric(metric_name)
+        return self._metadata_accessor.get_metric(metric_name)
 
     def make_metric(self, name, metadata, created_on=None, updated_on=None, read_on=None):
         """See the real Accessor for a description."""
@@ -137,10 +137,10 @@ class HybridAccessor(bg_accessor.Accessor):
         self._metadata_accessor.shutdown()
         self._data_accessor.shutdown()
 
-    def touch_metric(self, metric_name):
+    def touch_metric(self, metric):
         """See the real Accessor for a description."""
-        super(HybridAccessor, self).touch_metric(metric_name)
-        self._metadata_accessor.touch_metric(metric_name)
+        super(HybridAccessor, self).touch_metric(metric)
+        self._metadata_accessor.touch_metric(metric)
 
     def clean(self, max_age=None, start_key=None, end_key=None, shard=1, nshards=0,
               callback_on_progress=None):

--- a/biggraphite/drivers/memory.py
+++ b/biggraphite/drivers/memory.py
@@ -178,9 +178,9 @@ class _MemoryAccessor(bg_accessor.Accessor):
         super(_MemoryAccessor, self).has_metric(metric_name)
         return self.get_metric(metric_name) is not None
 
-    def get_metric(self, metric_name, touch=False):
+    def get_metric(self, metric_name):
         """See the real Accessor for a description."""
-        super(_MemoryAccessor, self).get_metric(metric_name, touch=touch)
+        super(_MemoryAccessor, self).get_metric(metric_name)
         metric_name = ".".join(self._components_from_name(metric_name))
         return self._name_to_metric.get(metric_name)
 
@@ -206,9 +206,9 @@ class _MemoryAccessor(bg_accessor.Accessor):
         return bg_accessor.PointGrouper(
             metric, time_start_ms, time_end_ms, stage, query_results, aggregated=aggregated)
 
-    def touch_metric(self, metric_name):
+    def touch_metric(self, metric):
         """See the real Accessor for a description."""
-        super(_MemoryAccessor, self).touch_metric(metric_name)
+        super(_MemoryAccessor, self).touch_metric(metric)
 
         # TODO Implements the function
         log.warn("%s is not implemented" % self.touch_metric.__name__)

--- a/biggraphite/metadata_cache.py
+++ b/biggraphite/metadata_cache.py
@@ -172,7 +172,7 @@ class MetadataCache(object):
                 self._cache_set(metric_name, metric)
         return found
 
-    def get_metric(self, metric_name, touch=False):
+    def get_metric(self, metric_name):
         """Return a Metric for this metric_name, None if no such metric."""
         metric, hit = self._cache_get(metric_name)
         if hit:
@@ -182,7 +182,7 @@ class MetadataCache(object):
         # Check that is still doesn't exists.
         if not metric:
             with self._accessor_lock:
-                metric = self._accessor.get_metric(metric_name, touch=touch)
+                metric = self._accessor.get_metric(metric_name)
                 self._cache_set(metric_name, metric)
 
         return metric

--- a/biggraphite/plugins/carbon.py
+++ b/biggraphite/plugins/carbon.py
@@ -146,7 +146,7 @@ class BigGraphiteDatabase(database.TimeSeriesDatabase):
         metric_name = self.encode(metric_name)
 
         # Get a Metric object from metric name.
-        metric = self.cache.get_metric(metric_name=metric_name, touch=True)
+        metric = self.cache.get_metric(metric_name=metric_name)
         if not metric:
             raise Exception('Could not find %s' % (metric_name))
 
@@ -191,7 +191,7 @@ class BigGraphiteDatabase(database.TimeSeriesDatabase):
 
     def getMetadata(self, metric_name, key):
         metric_name = self.encode(metric_name)
-        metadata = self.cache.get_metric(metric_name=metric_name, touch=True)
+        metadata = self.cache.get_metric(metric_name=metric_name)
 
         if not metadata:
             raise ValueError("%s: No such metric" % metric_name)
@@ -211,7 +211,7 @@ class BigGraphiteDatabase(database.TimeSeriesDatabase):
         old_value = self.getMetadata(metric_name, key)
         if old_value != value:
             metadata = self.cache.get_metric(
-                metric_name=metric_name, touch=True)
+                metric_name=metric_name)
             if not metadata:
                 raise ValueError("%s: No such metric" % metric_name)
 
@@ -287,7 +287,7 @@ class BigGraphiteDatabase(database.TimeSeriesDatabase):
         except queue.Empty:
             return
 
-        existing_metric = self.accessor.get_metric(metric.name, touch=True)
+        existing_metric = self.accessor.get_metric(metric.name)
 
         if metric == existing_metric:
             return

--- a/tests/drivers/test_hybrid.py
+++ b/tests/drivers/test_hybrid.py
@@ -107,7 +107,7 @@ class TestHybridAccessor(unittest.TestCase):
         self._accessor.connect()
         self._accessor.get_metric(DEFAULT_METRIC_NAME)
 
-        self._metadata_accessor.get_metric.assert_called_with(DEFAULT_METRIC_NAME, False)
+        self._metadata_accessor.get_metric.assert_called_with(DEFAULT_METRIC_NAME)
         self._data_accessor.get_metric.assert_not_called()
 
     def test_make_metric_should_be_called_only_for_metadata(self):


### PR DESCRIPTION
A boolean modifying the behavior of a method can be confusing.
Callers with the need to touch the metric will have to call it manually