### PR TITLE
elasticsearch: fix fetch_points()

### DIFF
--- a/biggraphite/drivers/elasticsearch.py
+++ b/biggraphite/drivers/elasticsearch.py
@@ -29,9 +29,7 @@ import time
 from biggraphite import accessor as bg_accessor
 from biggraphite import glob_utils as bg_glob
 from biggraphite.drivers import _utils
-
-from biggraphite.drivers.ttls import DEFAULT_READ_ON_TTL_SEC, DEFAULT_UPDATED_ON_TTL_SEC
-from biggraphite.drivers.ttls import str_to_datetime, str_to_timestamp, datetime_to_str
+from biggraphite.drivers import ttls
 
 log = logging.getLogger(__name__)
 
@@ -134,8 +132,6 @@ OPTIONS = {
     "port": int,
     "timeout": float,
 }
-
-UNDEFINED_RESULT = None
 
 
 def add_argparse_arguments(parser):
@@ -324,8 +320,8 @@ class _ElasticSearchAccessor(bg_accessor.Accessor):
         username=DEFAULT_USERNAME,
         password=DEFAULT_PASSWORD,
         timeout=DEFAULT_TIMEOUT,
-        updated_on_ttl_sec=DEFAULT_UPDATED_ON_TTL_SEC,
-        read_on_ttl_sec=DEFAULT_READ_ON_TTL_SEC,
+        updated_on_ttl_sec=ttls.DEFAULT_UPDATED_ON_TTL_SEC,
+        read_on_ttl_sec=ttls.DEFAULT_READ_ON_TTL_SEC,
     ):
         """Create a new ElasticSearchAccessor."""
         super(_ElasticSearchAccessor, self).__init__("ElasticSearch")
@@ -628,9 +624,9 @@ class _ElasticSearchAccessor(bg_accessor.Accessor):
         return self.make_metric(
             document.name,
             metadata,
-            created_on=str_to_datetime(document.created_on),
-            updated_on=str_to_datetime(document.updated_on),
-            read_on=str_to_datetime(document.read_on)
+            created_on=ttls.str_to_datetime(document.created_on),
+            updated_on=ttls.str_to_datetime(document.updated_on),
+            read_on=ttls.str_to_datetime(document.read_on)
         )
 
     def __get_document(self, metric_name):
@@ -653,7 +649,7 @@ class _ElasticSearchAccessor(bg_accessor.Accessor):
             metric, time_start, time_end, stage
         )
         self.__update_read_on_on_need(metric)
-        return UNDEFINED_RESULT
+        return []
 
     def touch_metric(self, metric_name):
         """See the real Accessor for a description."""
@@ -680,7 +676,7 @@ class _ElasticSearchAccessor(bg_accessor.Accessor):
             }
         }
         self.__update_document(data, index, document_id)
-        document.updated_on = datetime_to_str(updated_on)
+        document.updated_on = ttls.datetime_to_str(updated_on)
 
     def repair(self, *args, **kwargs):
         """See the real Accessor for a description."""
@@ -726,7 +722,7 @@ class _ElasticSearchAccessor(bg_accessor.Accessor):
         if not document.updated_on:
             delta = self.__updated_on_ttl_sec + 1
         else:
-            updated_on_timestamp = str_to_timestamp(document.updated_on)
+            updated_on_timestamp = ttls.str_to_timestamp(document.updated_on)
             delta = int(time.time()) - int(updated_on_timestamp)
 
         if delta >= self.__updated_on_ttl_sec:
@@ -736,7 +732,7 @@ class _ElasticSearchAccessor(bg_accessor.Accessor):
         if not metric.read_on:
             delta = self.__read_on_ttl_sec + 1
         else:
-            read_on_timestamp = str_to_timestamp(metric.read_on)
+            read_on_timestamp = ttls.str_to_timestamp(metric.read_on)
             delta = int(time.time()) - int(read_on_timestamp)
 
         if delta >= self.__read_on_ttl_sec:

--- a/biggraphite/drivers/ttls.py
+++ b/biggraphite/drivers/ttls.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Time constants and functions used by accessors."""
 
+import datetime
 import dateutil
 import time
 
@@ -27,6 +28,9 @@ DEFAULT_UPDATED_ON_TTL_SEC = 3 * DAY
 
 def str_to_datetime(str_repr):
     """Convert a string into a datetime."""
+    # Allow the caller to be stupid.
+    if type(str_repr) == datetime.datetime:
+        return str_repr
     if not str_repr:
         return None
     return dateutil.parser.parse(str_repr)


### PR DESCRIPTION
The new unit test would have caused:
```
======================================================================
ERROR: test_fetch_points_updates_read_on (__main__.TestAccessorWithElasticsearch)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/drivers/test_elasticsearch.py", line 361, in test_fetch_points_updates_read_on
    points = self.accessor.fetch_points(metric, 0, 1, metric.retention[0])
  File "/home/cchary/dev/graphite/biggraphite/biggraphite/drivers/elasticsearch.py", line 651, in fetch_points
    self.__update_read_on_on_need(metric)
  File "/home/cchary/dev/graphite/biggraphite/biggraphite/drivers/elasticsearch.py", line 735, in __update_read_on_on_need
    read_on_timestamp = ttls.str_to_timestamp(metric.read_on)
  File "/home/cchary/dev/graphite/biggraphite/biggraphite/drivers/ttls.py", line 43, in str_to_timestamp
    datetime_tuple = str_to_datetime(str_repr)
  File "/home/cchary/dev/graphite/biggraphite/biggraphite/drivers/ttls.py", line 36, in str_to_datetime
    return dateutil.parser.parse(str_repr)
  File "/home/cchary/dev/graphite/biggraphite/venv/lib/python3.6/site-packages/dateutil/parser/_parser.py", line 1356, in parse
    return DEFAULTPARSER.parse(timestr, **kwargs)
  File "/home/cchary/dev/graphite/biggraphite/venv/lib/python3.6/site-packages/dateutil/parser/_parser.py", line 645, in parse
    res, skipped_tokens = self._parse(timestr, **kwargs)
  File "/home/cchary/dev/graphite/biggraphite/venv/lib/python3.6/site-packages/dateutil/parser/_parser.py", line 721, in _parse
    l = _timelex.split(timestr)         # Splits the timestr into tokens
  File "/home/cchary/dev/graphite/biggraphite/venv/lib/python3.6/site-packages/dateutil/parser/_parser.py", line 207, in split
    return list(cls(s))
  File "/home/cchary/dev/graphite/biggraphite/venv/lib/python3.6/site-packages/dateutil/parser/_parser.py", line 76, in __init__
    '{itype}'.format(itype=instream.__class__.__name__))
TypeError: Parser must be a string or character stream, not datetime
```

Also:
* Make TestAccessorWithElasticsearch inherit directly from
  BaseTestAccessorMetadata. This makes more sense because we
  use self.assert* inside it.
* Change ttls.str_from_datetime() to allow datetimes as arguments.