### PR TITLE
Match tox configuration with Travis

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 [tox]
-envlist = {py27,py3,pypy}-coverage,pylama
+envlist = {py27,py36,pypy}-coverage,pylama
 
 [testenv]
 commands =


### PR DESCRIPTION
Travis defines 3 envs:
 * python 2.7
 * python 3.6
 * pypy

Tox did not have python 3.6 but python 3.
