### PR TITLE
elasticsearch: ignore missing documents in touch_metric()

### DIFF
--- a/biggraphite/drivers/elasticsearch.py
+++ b/biggraphite/drivers/elasticsearch.py
@@ -653,6 +653,11 @@ class _ElasticSearchAccessor(bg_accessor.Accessor):
         super(_ElasticSearchAccessor, self).touch_metric(metric)
         metric_name = bg_accessor.sanitize_metric_name(metric.name)
         document = self.__get_document(metric_name)
+
+        # The metric might not exist in elasticsearch yet.
+        if not document:
+            return
+
         if not document.updated_on:
             delta = self.__updated_on_ttl_sec + 1
         else:

--- a/tests/drivers/base_test_metadata.py
+++ b/tests/drivers/base_test_metadata.py
@@ -367,3 +367,9 @@ class BaseTestAccessorMetadata(object):
             self.assertIsNotNone(name)
 
         self.accessor.map(_callback, errback=_errback)
+
+    def test_touch_without_create(self):
+        metric = self.make_metric("foo")
+        self.accessor.touch_metric(metric)
+        self.accessor.create_metric(metric)
+        self.accessor.touch_metric(metric)


### PR DESCRIPTION
Without the fix, the test raises the following error:
```
======================================================================
ERROR: test_touch_without_create (__main__.TestAccessorWithElasticsearch)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/cchary/dev/graphite/biggraphite/tests/drivers/base_test_metadata.py", line 373, in test_touch_without_create
    self.accessor.touch_metric(metric)
  File "/home/cchary/dev/graphite/biggraphite/biggraphite/drivers/elasticsearch.py", line 661, in touch_metric
    if not document.updated_on:
AttributeError: 'NoneType' object has no attribute 'updated_on'
```