### PR TITLE
drivers: make sure touch_metric() also changes the metric

### DIFF
--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -24,6 +24,7 @@ import os
 import random
 import time
 import six
+import datetime
 from os import path as os_path
 from distutils import version
 
@@ -1686,6 +1687,11 @@ class _CassandraAccessor(bg_accessor.Accessor):
         else:
             delta = int(time.time()) - int(time.mktime(metric.updated_on.timetuple()) / 1000)
         if delta >= self.__metadata_touch_ttl_sec:
+            # Make sure the caller also see the change without refreshing
+            # the metric.
+            metric.updated_on = datetime.datetime.now()
+
+            # Update Cassandra.
             self._execute_async_metadata(
                 self.__touch_metrics_metadata_statement,
                 (metric.name,)


### PR DESCRIPTION
Currently it changes the database but not the object used
as a parameter. Since both are not synced, the next call
will re-trigger a database update even if there was no need
for it.

In elasticsearch also fetch the document only when we really
need, else we end up doing one synchronous query each time
we write a point.