### PR TITLE
ES: ignore 409 HTTP status codes on document update

### DIFF
--- a/biggraphite/drivers/elasticsearch.py
+++ b/biggraphite/drivers/elasticsearch.py
@@ -768,7 +768,7 @@ class _ElasticSearchAccessor(bg_accessor.Accessor):
             doc_type=INDEX_DOC_TYPE,
             id=document_id,
             body=data,
-            ignore=404
+            ignore=[404, 409]
         )
 
     def _create_search_query(self):


### PR DESCRIPTION
409 code means there is a conflict at document update time.
We do not need strong consistency on metadata so we can ignore an error
once in a while.
