### PR TITLE
Removed clear method.

### DIFF
--- a/biggraphite/accessor.py
+++ b/biggraphite/accessor.py
@@ -265,11 +265,6 @@ class Accessor(object):
         """Flush any internal buffers."""
         pass
 
-    @abc.abstractmethod
-    def clear(self):
-        """Clear all internal data."""
-        pass
-
     def insert_points(self, metric, datapoints):
         """Insert points for a given metric.
 

--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -1246,6 +1246,10 @@ class _CassandraAccessor(bg_accessor.Accessor):
             for table in tables:
                 self._execute(
                     session, "TRUNCATE \"%s\".\"%s\";" % (keyspace, table))
+        if self.__downsampler:
+            self.__downsampler.clear()
+        if self.__delayed_writer:
+            self.__delayed_writer.clear()
 
     def fetch_points(self, metric, time_start, time_end, stage, aggregated=True):
         """See bg_accessor.Accessor."""
@@ -1516,13 +1520,6 @@ class _CassandraAccessor(bg_accessor.Accessor):
             self.__delayed_writer.flush()
         if self.__lazy_statements:
             self.__lazy_statements.flush()
-
-    def clear(self):
-        """Clear all internal data."""
-        if self.__downsampler:
-            self.__downsampler.clear()
-        if self.__delayed_writer:
-            self.__delayed_writer.clear()
 
     def insert_points_async(self, metric, datapoints, on_done=None):
         """See bg_accessor.Accessor."""

--- a/biggraphite/drivers/elasticsearch.py
+++ b/biggraphite/drivers/elasticsearch.py
@@ -366,10 +366,6 @@ class _ElasticSearchAccessor(bg_accessor.Accessor):
                 ignore_unavailable=True,
             )
 
-    def clear(self):
-        """Clear all internal data."""
-        self._known_indices = {}
-
     def get_index(self, metric):
         """Get the index where a metric should be stored."""
         # Here the index could be sharded further by looking at the
@@ -406,6 +402,7 @@ class _ElasticSearchAccessor(bg_accessor.Accessor):
         super(_ElasticSearchAccessor, self).drop_all_metrics(*args, **kwargs)
         # Drop indices.
         self.client.indices.delete("%s*" % self._index_prefix)
+        self._known_indices = {}
 
     def create_metric(self, metric):
         """See the real Accessor for a description."""

--- a/biggraphite/drivers/hybrid.py
+++ b/biggraphite/drivers/hybrid.py
@@ -96,12 +96,6 @@ class HybridAccessor(bg_accessor.Accessor):
         self._metadata_accessor.flush()
         self._data_accessor.flush()
 
-    def clear(self):
-        """See the real Accessor for a description."""
-        super(HybridAccessor, self).clear()
-        self._metadata_accessor.clear()
-        self._data_accessor.clear()
-
     def insert_points_async(self, metric, datapoints, on_done=None):
         """See the real Accessor for a description."""
         super(HybridAccessor, self).insert_points_async(metric, datapoints, on_done)

--- a/biggraphite/drivers/memory.py
+++ b/biggraphite/drivers/memory.py
@@ -89,13 +89,6 @@ class _MemoryAccessor(bg_accessor.Accessor):
         if self.__delayed_writer:
             self.__delayed_writer.flush()
 
-    def clear(self):
-        """Clear all internal data."""
-        if self.__downsampler:
-            self.__downsampler.clear()
-        if self.__delayed_writer:
-            self.__delayed_writer.clear()
-
     def insert_points_async(self, metric, datapoints, on_done=None):
         """See the real Accessor for a description."""
         super(_MemoryAccessor, self).insert_points_async(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -230,7 +230,6 @@ class TestCaseWithAccessor(TestCaseWithTempDir):
         super(TestCaseWithAccessor, self).tearDown()
         self.metadata_cache.close()
         self.accessor.flush()
-        self.accessor.clear()
         self.__drop_all_metrics()
 
     def flush(self):


### PR DESCRIPTION
It brings confusion and is only called by tests.