### PR TITLE
bgutil won't start without IPython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,5 +31,5 @@ prometheus_client
 # Metadata cache
 lmdb
 
-# Optional, for bgutil shell:
-# ipython
+# For bgutil shell
+ipython


### PR DESCRIPTION
Add it as a required dependency.
