### PR TITLE
Fix query limit while fetching points using cassandra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 # IDEs
 **/.idea/
 **/*.iml
+.vscode/
 *~
 
 # dev virtualenvs


### PR DESCRIPTION
See CASSANDRA_DESIGN.md. We added a shard_id to avoid
data loss on restarts. On restart the data of some
given datapoints may be spread on several cassandra cells.

Limit of fetch data queries were computed with no
restart, and then may be too short in case of restarts.
This may create artificial loss at read time.