### PR TITLE
elasticsearch: fix read_on, again

### DIFF
--- a/biggraphite/drivers/elasticsearch.py
+++ b/biggraphite/drivers/elasticsearch.py
@@ -789,9 +789,9 @@ class _ElasticSearchAccessor(bg_accessor.Accessor):
 
     @READ_ON.time()
     def __update_read_on_on_need(self, metric):
-        # TODO: remove the sampling rate once graphite.py stops using a cache (that doesn't get
-        # updated when we updated read_on). Instead we should collect the latest read_on when we list
-        # metrics.
+        # TODO: remove the sampling rate once graphite.py stops using a cache
+        # (that doesn't get updated when we updated read_on). Instead we
+        # should collect the latest read_on when we list metrics.
         rate = int(1 / self.__read_on_sampling_rate)
 
         skip = self.__read_on_counter % rate > 0

--- a/biggraphite/drivers/elasticsearch.py
+++ b/biggraphite/drivers/elasticsearch.py
@@ -796,11 +796,12 @@ class _ElasticSearchAccessor(bg_accessor.Accessor):
             self.__update_read_on(metric)
 
     def __update_read_on(self, metric):
-        # TODO: state if we should move the document from its index to
-        # the current (today) index
         data = {"doc": {"read_on": datetime.datetime.now()}}
-        index = self.get_index(metric.name)
-        self.__update_document(data, index, metric.id)
+
+        # Get the latest version of the metric and update it.
+        document = self.__get_document(metric.name)
+        self.__update_document(data, document.meta.index, metric.id)
+
         # Make sure the caller also see the change without refreshing
         # the metric.
         metric.read_on = datetime.datetime.now()


### PR DESCRIPTION
The previous code would update the latest index only, even
if the metric is on another one. Now we fetch the latest document
and we update read_on on this one.