### PR TITLE
setup.py: include enum and futures only for python 2.7

### DIFF
--- a/biggraphite/drivers/elasticsearch.py
+++ b/biggraphite/drivers/elasticsearch.py
@@ -376,7 +376,7 @@ class _ElasticSearchAccessor(bg_accessor.Accessor):
         if self._executor:
             # Since we have a single thread, it's cheap way to join()
             future = self._executor.submit(lambda: True)
-            future.result(timeout=1)
+            future.result(timeout=5)
 
         # Then, make sure we can read everything we wrote.
         if self.client:

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ certifi
 
 # Core
 six
-enum34
 cachetools
 prometheus_client
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,10 @@
 """setuptools integration for BigGraphite."""
 import os
 import setuptools
+import sys
+
+
+PY3 = sys.version_info.major == 3
 
 
 def _read(relpath):
@@ -34,6 +38,10 @@ def _read_reqs(relpath):
 _REQUIREMENTS_TXT = _read_reqs("requirements.txt")
 _DEPENDENCY_LINKS = [l for l in _REQUIREMENTS_TXT if "://" in l]
 _INSTALL_REQUIRES = [l for l in _REQUIREMENTS_TXT if "://" not in l]
+
+
+if not PY3:
+  _INSTALL_REQUIRES += ('futures', 'enum34')
 
 
 packages = setuptools.find_packages()


### PR DESCRIPTION
Installing enum in python 3.6 will break everything.