### PR TITLE
carbon: make sure updated_on gets written

### DIFF
--- a/biggraphite/plugins/carbon.py
+++ b/biggraphite/plugins/carbon.py
@@ -181,7 +181,13 @@ class BigGraphiteDatabase(database.TimeSeriesDatabase):
             retention=bg_metric.Retention.from_carbon(retentions),
             carbon_xfilesfactor=xfilesfactor,
         )
-        metric = bg_metric.make_metric(metric_name, metadata)
+        metric = bg_metric.make_metric(
+            metric_name, metadata,
+            # Don't set updated_on to make sure it gets written when
+            # necessary. This also means all `updated_on` gets re-written
+            # after each carbon restart.
+            updated_on=None,
+        )
         self.cache.cache_set(metric_name, metric)
         self._createAsync(metric, orig_metric_name)
 


### PR DESCRIPTION
Without this, metrics would all have updated_on set
to `now` meaning it would not get updated if the process
restarts before the ttl expiration (three days).