### PR TITLE
Add `enum-compat` requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ elasticsearch-dsl
 certifi
 
 # Core
+enum-compat
 six
 cachetools
 prometheus_client


### PR DESCRIPTION
Used in metric.py for `@enum.unique`
