### PR TITLE
Hybrid accessor: no longer make calls to data accessor for metadata actions

### DIFF
--- a/biggraphite/accessor.py
+++ b/biggraphite/accessor.py
@@ -107,6 +107,7 @@ class Accessor(object):
         self.cache = None
         self.cache_data_ttl = None
         self.cache_metadata_ttl = None
+        self.metadata_enabled = True
 
     def __enter__(self):
         """Call connect()."""
@@ -291,7 +292,9 @@ class Accessor(object):
         if not isinstance(metric, bg_metric.Metric):
             raise InvalidArgumentError("%s is not a Metric instance" % metric)
         self._check_connected()
-        self.touch_metric(metric)
+
+        if self.metadata_enabled:
+            self.touch_metric(metric)
 
     def insert_downsampled_points(self, metric, datapoints):
         """Insert points for a given metric.

--- a/biggraphite/accessor_factory.py
+++ b/biggraphite/accessor_factory.py
@@ -88,6 +88,14 @@ def accessor_from_settings(settings):
                 "Data driver is not provided. Please specify --data_driver"
             )
 
+        # The data accessor may still update the metadata in its own storage
+        # (update_on on insert_points(), read_on on fetch_points()). Since we
+        # are in hybrid mode, the metadata accessor is responsible for these
+        # actions, therefore we can disable the metadata handling in the data
+        # accessor.
+        enable_metadata_key = data_driver + '_enable_metadata'
+        settings[enable_metadata_key] = False
+
         metadata_accessor = _build_simple_accessor(metadata_driver, settings)
         data_accessor = _build_simple_accessor(data_driver, settings)
 

--- a/biggraphite/drivers/hybrid.py
+++ b/biggraphite/drivers/hybrid.py
@@ -178,3 +178,8 @@ class HybridAccessor(bg_accessor.Accessor):
         super(HybridAccessor, self).shutdown()
         self._metadata_accessor.shutdown()
         self._data_accessor.shutdown()
+
+    def syncdb(self, retentions=None, dry_run=False):
+        """See the real Accessor for a description."""
+        self._metadata_accessor.syncdb(retentions, dry_run)
+        self._data_accessor.syncdb(retentions, dry_run)

--- a/tests/drivers/test_cassandra.py
+++ b/tests/drivers/test_cassandra.py
@@ -205,10 +205,10 @@ class TestAccessorWithCassandraData(bg_test_utils.TestCaseWithAccessor):
         self.flush()
         self.cassandra_helper.cluster.refresh_schema_metadata()
 
-        keyspace = None
-        for name, keyspace in self.cassandra_helper.cluster.metadata.keyspaces.items():
-            if name == self.accessor.keyspace:
-                break
+        self.assertTrue(
+            self.cassandra_helper.KEYSPACE in self.cassandra_helper.cluster.metadata.keyspaces
+        )
+        keyspace = self.cassandra_helper.cluster.metadata.keyspaces[self.cassandra_helper.KEYSPACE]
 
         datapoints_86400p_1s = keyspace.tables["datapoints_86400p_1s_0"]
         options = datapoints_86400p_1s.options
@@ -253,10 +253,10 @@ class TestAccessorWithCassandraData(bg_test_utils.TestCaseWithAccessor):
         self.flush()
         self.cassandra_helper.cluster.refresh_schema_metadata()
 
-        keyspace = None
-        for name, keyspace in self.cassandra_helper.cluster.metadata.keyspaces.items():
-            if name == self.accessor.keyspace:
-                break
+        self.assertTrue(
+            self.cassandra_helper.KEYSPACE in self.cassandra_helper.cluster.metadata.keyspaces
+        )
+        keyspace = self.cassandra_helper.cluster.metadata.keyspaces[self.cassandra_helper.KEYSPACE]
 
         datapoints_86400p_1s = keyspace.tables["datapoints_86400p_1s_0"]
         options = datapoints_86400p_1s.options
@@ -284,6 +284,18 @@ class TestAccessorWithCassandraData(bg_test_utils.TestCaseWithAccessor):
         retentions = [bg_metric.Retention.from_string("60*1s:60*60s")]
         self.accessor.syncdb(retentions=retentions, dry_run=True)
         self.accessor.syncdb(retentions=retentions, dry_run=False)
+
+
+@unittest.skipUnless(HAS_CASSANDRA, "CASSANDRA_HOME must be set to a >=3.5 install")
+class TestAccessorWithHybridCassandraData(TestAccessorWithCassandraData):
+    ACCESSOR_SETTINGS = {
+        "driver": "hybrid",
+        "data_driver": "cassandra",
+        "metadata_driver": "memory"
+    }
+
+    def test_metadata_disabled(self):
+        self.assertFalse(self.accessor._data_accessor.metadata_enabled)
 
 
 if __name__ == "__main__":

--- a/tests/test_accessor_factory.py
+++ b/tests/test_accessor_factory.py
@@ -16,6 +16,7 @@
 from __future__ import print_function
 
 import unittest
+import mock
 
 from biggraphite import accessor_factory as bg_accessor_factory
 from biggraphite import settings as bg_settings
@@ -42,6 +43,17 @@ class TestAccessorFactory(unittest.TestCase):
         settings = bg_settings.settings_from_confattr(settings)
         accessor = bg_accessor_factory.accessor_from_settings(settings)
         self.assertNotEqual(accessor, None)
+
+    @mock.patch('biggraphite.drivers.cassandra._CassandraAccessor')
+    def test_hybrid_accessor(self, cassandra_accessor_mock):
+        settings = {
+                    "BG_DATA_DRIVER": "cassandra",
+                    "BG_METADATA_DRIVER": "memory"
+                }
+        settings = bg_settings.settings_from_confattr(settings)
+        accessor = bg_accessor_factory.accessor_from_settings(settings)
+        self.assertNotEqual(accessor, None)
+        cassandra_accessor_mock.assert_called_with(enable_metadata=False)
 
 
 if __name__ == "__main__":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -204,6 +204,13 @@ class TestCaseWithAccessor(TestCaseWithTempDir):
             cls.ACCESSOR_SETTINGS.update(
                 cls.elasticsearch_helper.get_accessor_settings()
             )
+        if "hybrid" in driver_name:
+            if cls.ACCESSOR_SETTINGS['data_driver'] == 'cassandra':
+                cls.cassandra_helper = CassandraHelper()
+                cls.cassandra_helper.setUpClass()
+                cls.ACCESSOR_SETTINGS.update(
+                    cls.cassandra_helper.get_accessor_settings()
+                )
 
         cls.accessor = bg_accessor_factory.accessor_from_settings(cls.ACCESSOR_SETTINGS)
         cls.accessor.syncdb()

--- a/tests/test_utils_cassandra.py
+++ b/tests/test_utils_cassandra.py
@@ -133,7 +133,7 @@ class CassandraHelper:
         """Flush all kind of buffers related to Cassandra."""
         # When using Lucene, we need to force a refresh on the index as the default
         # refresh period is 60s.
-        if accessor.use_lucene:
+        if accessor.TYPE == 'cassandra-lucene':
             statements = accessor.metadata_query_generator.sync_queries()
             for statement in statements:
                 self.session.execute(statement)


### PR DESCRIPTION
When using the hybrid mode, data and metadata accessors are both updating read_on and update_on metadata.

This is a problem because this makes mandatory to specify the metadata storage configuration for the data accessor while it is not used.

The solution consist in passing a flag preventing the data accessor to use the metadata storage when the hybrid mode is used.