### PR TITLE
Monitor Cassandra queries

### DIFF
--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -186,10 +186,6 @@ REPAIR_DIRECTORIES_TO_CREATE = prometheus_client.Counter(
 )
 
 
-READ_ON = prometheus_client.Summary(
-    "bg_cassandra_read_on_latency_seconds",
-    "create latency in seconds"
-)
 SYNCDB_DATA = prometheus_client.Summary(
     "bg_cassandra_syncdb_data_latency_seconds",
     "DB data sync latency in seconds"
@@ -1658,11 +1654,10 @@ class _CassandraAccessor(bg_accessor.Accessor):
         if skip:
             return
 
-        with READ_ON.time():
-            log.debug("updating read_on for %s" % metric_name)
-            self._execute_async_metadata(
-                self.__update_metric_read_on_metadata_statement.with_params(metric_name)
-            )
+        log.debug("updating read_on for %s" % metric_name)
+        self._execute_async_metadata(
+            self.__update_metric_read_on_metadata_statement.with_params(metric_name)
+        )
 
     def _select_metric(self, metric_name):
         """Fetch metric metadata."""

--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -52,6 +52,78 @@ from biggraphite.drivers import cassandra_stratio_lucene as lucene
 from biggraphite.drivers.ttls import DAY, HOUR, MINUTE
 from biggraphite.drivers.ttls import DEFAULT_UPDATED_ON_TTL_SEC
 
+DELETE_METRIC_METADATA = prometheus_client.Counter(
+    "bg_cassandra_delete_metric_metadata",
+    "Number of metrics metadata that have been deleted",
+)
+DELETE_DIRECTORY = prometheus_client.Counter(
+    "bg_cassandra_delete_directory",
+    "Number of directories that have been deleted",
+)
+DELETE_METRIC = prometheus_client.Counter(
+    "bg_cassandra_delete_metric",
+    "Number of metrics that has been deleted",
+)
+UPDATE_READ_ON_METADATA = prometheus_client.Counter(
+    "bg_cassandra_update_metric_read_on",
+    "Number of 'read_on' that have been updated in metric metadata",
+)
+INSERT_METRIC_METADATA = prometheus_client.Counter(
+    "bg_cassandra_insert_metric_metadata",
+    "Number of metrics metadata that has been inserted",
+)
+TOUCH_METRIC_METADATA = prometheus_client.Counter(
+    "bg_cassandra_touch_metric_metadata",
+    "Number of metrics metadata that has been touched",
+)
+UPDATE_METRIC_METADATA = prometheus_client.Counter(
+    "bg_cassandra_update_metric_metadata",
+    "Number of metrics metadata that has been updated",
+)
+SELECT_METRIC_METADATA = prometheus_client.Counter(
+    "bg_cassandra_select_metric_metadata",
+    "Number of metrics metadata that has been selected",
+)
+INSERT_DIRECTORY = prometheus_client.Counter(
+    "bg_cassandra_insert_directory",
+    "Number of directories that has been inserted",
+)
+INSERT_METRIC = prometheus_client.Counter(
+    "bg_cassandra_insert_metric",
+    "Number of metrics that has been inserted",
+)
+SELECT_METRIC = prometheus_client.Counter(
+    "bg_cassandra_select_metric",
+    "Number of metrics that has been selected",
+)
+SELECT_DIRECTORY = prometheus_client.Counter(
+    "bg_cassandra_select_directory",
+    "Number of directories that has been selected",
+)
+SELECT = prometheus_client.Counter(
+    "bg_cassandra_select",
+    "Number of glob select",
+)
+METADATA_SCHEMA_UPDATE = prometheus_client.Counter(
+    "bg_cassandra_creation_cql_metadata",
+    "Number of schema changes that has been executed so far",
+)
+SELECT_TABLES_FROM_KEYSPACE = prometheus_client.Counter(
+    "bg_cassandra_select_tables_from_keyspace",
+    "Number of times tables from keyspace have been selected",
+)
+CLEAN_EXPIRED_METRICS_SELECT = prometheus_client.Counter(
+    "bg_cassandra_clean_expired_metrics_select",
+    "Number of select to prepare cleaning expired metrics",
+)
+CLEAN_EXPIRED_METRICS_DELETE = prometheus_client.Counter(
+    "bg_cassandra_clean_expired_metrics_delete",
+    "Number of expired metrics delete",
+)
+CLEAN_EXPIRED_METRICS_DELETE_METADATA = prometheus_client.Counter(
+    "bg_cassandra_clean_expired_metrics_delete_metadata",
+    "Number of expired metrics metadata delete",
+)
 PM_DELETED_DIRECTORIES = prometheus_client.Counter(
     "bg_cassandra_deleted_directories",
     "Number of directory that have been deleted so far",
@@ -63,6 +135,55 @@ PM_EXPIRED_METRICS = prometheus_client.Counter(
     "bg_cassandra_expired_metrics",
     "Number of metrics that has been cleaned due to expiration",
 )
+INSERT_DOWNSAMPLED_POINTS = prometheus_client.Counter(
+    "bg_cassandra_insert_downsampled_points",
+    "Number of downsampled point insertion",
+)
+INSERT_DOWNSAMPLED_POINTS_BATCH = prometheus_client.Counter(
+    "bg_cassandra_insert_downsampled_points_batch",
+    "Number of batched downsampled point insertion",
+)
+SYNCDB = prometheus_client.Counter(
+    "bg_cassandra_syncdb",
+    "Number of requests to syncdb",
+)
+CLEAN = prometheus_client.Counter(
+    "bg_cassandra_clean_empty_dir",
+    "Number of directory cleaning",
+)
+CLEAN_DIRECTORIES_TO_CHECK = prometheus_client.Counter(
+    "bg_cassandra_clean_empty_dir_directories_to_check",
+    "Number of queries performed to find directories to check during directory cleaning",
+)
+CLEAN_DIRECTORIES_TO_REMOVE = prometheus_client.Counter(
+    "bg_cassandra_clean_empty_dir_directories_to_remove",
+    "Number of queries performed to remove directories during directory cleaning",
+)
+REPAIR_MISSING_DIR_COUNT = prometheus_client.Counter(
+    "bg_cassandra_repair_missing_dir",
+    "Number of missing dir repair",
+)
+MAP_ITERATION = prometheus_client.Counter(
+    "bg_cassandra_map_iteration",
+    "Number of iteration on map so far",
+)
+DROP_ALL_METRICS = prometheus_client.Counter(
+    "bg_cassandra_drop_all_metrics",
+    "Number of drop all triggers",
+)
+FETCH_POINT = prometheus_client.Counter(
+    "bg_cassandra_fetch_point",
+    "Number of point fetch",
+)
+REPAIR_DIRECTORIES_TO_CHECK = prometheus_client.Counter(
+    "bg_cassandra_repair_directories_to_check",
+    "Number of queries to find directories to check during a repair",
+)
+REPAIR_DIRECTORIES_TO_CREATE = prometheus_client.Counter(
+    "bg_cassandra_repair_directories_to_create",
+    "Number of queries to create directories  during a repair",
+)
+
 
 UPDATED_ON = prometheus_client.Summary(
     "bg_cassandra_updated_on_latency_seconds",
@@ -92,11 +213,11 @@ REPAIR_MISSING_DIR = prometheus_client.Summary(
     "bg_cassandra_repair_missing_dir_latency_seconds",
     "repair missing directory latency in seconds"
 )
-SELECT_METRIC_METADATA = prometheus_client.Summary(
+SELECT_METRIC_METADATA_LATENCY = prometheus_client.Summary(
     "bg_cassandra_select_metric_metadata_latency_seconds",
     "select metric metadata latency in seconds"
 )
-DELETE_DIRECTORY = prometheus_client.Summary(
+DELETE_DIRECTORY_LATENCY = prometheus_client.Summary(
     "bg_cassandra_delete_directory_latency_seconds",
     "delete directory latency in seconds"
 )
@@ -874,6 +995,33 @@ def expose_metrics(metrics, cluster_name=""):
     return metrics_adp
 
 
+class _CassandraExecutionRequest(object):
+    """Wraps required data for a Cassandra query."""
+
+    def __init__(self, counter, statement, *params):
+        """Inits the execution request."""
+        self.counter = counter
+        self.statement = statement
+        self.params = params
+
+    def mark(self):
+        """Mark this context as executed."""
+        if self.counter:
+            self.counter.inc()
+
+    def args(self):
+        """Returns the query arguments as expected by the Cassandra driver."""
+        return self.statement, list(self.params)
+
+    def with_params(self, *params):
+        """Clone this execution request with parameters."""
+        return _CassandraExecutionRequest(self.counter, self.statement, *params)
+
+    def with_param_list(self, param_list):
+        """Clone this execution request with parameters as list."""
+        return self.with_params(*tuple(param_list))
+
+
 class _CassandraAccessor(bg_accessor.Accessor):
     """Provides Read/Write accessors to Cassandra.
 
@@ -1051,22 +1199,31 @@ class _CassandraAccessor(bg_accessor.Accessor):
             "component_%d" % n for n in range(_COMPONENTS_MAX_LEN)
         )
         components_marks = ", ".join("?" for n in range(_COMPONENTS_MAX_LEN))
-        self.__insert_metric_statement = __prepare(
-            'INSERT INTO "%s".metrics (name, parent, %s) VALUES (?, ?, %s);'
-            % (self.keyspace_metadata, components_names, components_marks)
+        self.__insert_metric_statement = _CassandraExecutionRequest(
+            INSERT_METRIC,
+            __prepare(
+                'INSERT INTO "%s".metrics (name, parent, %s) VALUES (?, ?, %s);'
+                % (self.keyspace_metadata, components_names, components_marks)
+            )
         )
-        self.__insert_directory_statement = __prepare(
-            'INSERT INTO "%s".directories (name, parent, %s) VALUES (?, ?, %s) IF NOT EXISTS;'
-            % (self.keyspace_metadata, components_names, components_marks)
+        self.__insert_directory_statement = _CassandraExecutionRequest(
+            INSERT_DIRECTORY,
+            __prepare(
+                'INSERT INTO "%s".directories (name, parent, %s) VALUES (?, ?, %s) IF NOT EXISTS;'
+                % (self.keyspace_metadata, components_names, components_marks)
+            )
         )
-        self.__insert_directory_statement.serial_consistency_level = (
+        self.__insert_directory_statement.statement.serial_consistency_level = (
             self._meta_serial_consistency
         )
         # We do not set the serial_consistency, it defautls to SERIAL.
-        self.__select_metric_metadata_statement = __prepare(
-            "SELECT id, config, toUnixTimestamp(updated_on), name"
-            ' FROM "%s".metrics_metadata WHERE name = ?;' % self.keyspace_metadata,
-            self._meta_read_consistency,
+        self.__select_metric_metadata_statement = _CassandraExecutionRequest(
+            SELECT_METRIC_METADATA,
+            __prepare(
+                "SELECT id, config, toUnixTimestamp(updated_on), name"
+                ' FROM "%s".metrics_metadata WHERE name = ?;' % self.keyspace_metadata,
+                self._meta_read_consistency,
+            )
         )
         self.__select_metric_statement = __prepare(
             'SELECT * FROM "%s".metrics WHERE name = ?;' % self.keyspace_metadata,
@@ -1076,34 +1233,54 @@ class _CassandraAccessor(bg_accessor.Accessor):
             'SELECT * FROM "%s".directories WHERE name = ?;' % self.keyspace_metadata,
             self._meta_read_consistency,
         )
-        self.__update_metric_metadata_statement = __prepare(
-            'UPDATE "%s".metrics_metadata SET config=?, updated_on=now()'
-            " WHERE name=?;" % self.keyspace_metadata
+        self.__update_metric_metadata_statement = _CassandraExecutionRequest(
+            UPDATE_METRIC_METADATA,
+            __prepare(
+                'UPDATE "%s".metrics_metadata SET config=?, updated_on=now()'
+                " WHERE name=?;" % self.keyspace_metadata
+            )
         )
-        self.__touch_metrics_metadata_statement = __prepare(
-            'UPDATE "%s".metrics_metadata SET updated_on=now()'
-            " WHERE name=?;" % self.keyspace_metadata
+        self.__touch_metrics_metadata_statement = _CassandraExecutionRequest(
+            TOUCH_METRIC_METADATA,
+            __prepare(
+                'UPDATE "%s".metrics_metadata SET updated_on=now()'
+                " WHERE name=?;" % self.keyspace_metadata
+            ))
+        self.__insert_metrics_metadata_statement = _CassandraExecutionRequest(
+            INSERT_METRIC_METADATA,
+            __prepare(
+                'INSERT INTO "%s".metrics_metadata (name, created_on, updated_on, id, config)'
+                " VALUES (?, now(), now(), ?, ?);" % self.keyspace_metadata
+            )
         )
-        self.__insert_metrics_metadata_statement = __prepare(
-            'INSERT INTO "%s".metrics_metadata (name, created_on, updated_on, id, config)'
-            " VALUES (?, now(), now(), ?, ?);" % self.keyspace_metadata
+        self.__update_metric_read_on_metadata_statement = _CassandraExecutionRequest(
+            UPDATE_READ_ON_METADATA,
+            __prepare(
+                'UPDATE "%s".metrics_metadata SET read_on=now()'
+                " WHERE name=?;" % self.keyspace_metadata
+            )
         )
-        self.__update_metric_read_on_metadata_statement = __prepare(
-            'UPDATE "%s".metrics_metadata SET read_on=now()'
-            " WHERE name=?;" % self.keyspace_metadata
+        self.__delete_metric = _CassandraExecutionRequest(
+            DELETE_METRIC,
+            __prepare(
+                'DELETE FROM "%s".metrics WHERE name=?;' % (self.keyspace_metadata),
+                consistency=cassandra.ConsistencyLevel.QUORUM,
+            )
         )
-        self.__delete_metric = __prepare(
-            'DELETE FROM "%s".metrics WHERE name=?;' % (self.keyspace_metadata),
-            consistency=cassandra.ConsistencyLevel.QUORUM,
+        self.__delete_directory = _CassandraExecutionRequest(
+            DELETE_DIRECTORY,
+            __prepare(
+                'DELETE FROM "%s".directories WHERE name=?;' % (self.keyspace_metadata),
+                consistency=cassandra.ConsistencyLevel.QUORUM,
+            )
         )
-        self.__delete_directory = __prepare(
-            'DELETE FROM "%s".directories WHERE name=?;' % (self.keyspace_metadata),
-            consistency=cassandra.ConsistencyLevel.QUORUM,
-        )
-        self.__delete_metric_metadata = __prepare(
-            'DELETE FROM "%s".metrics_metadata WHERE name=?;'
-            % (self.keyspace_metadata),
-            consistency=cassandra.ConsistencyLevel.QUORUM,
+        self.__delete_metric_metadata = _CassandraExecutionRequest(
+            DELETE_METRIC_METADATA,
+            __prepare(
+                'DELETE FROM "%s".metrics_metadata WHERE name=?;'
+                % (self.keyspace_metadata),
+                consistency=cassandra.ConsistencyLevel.QUORUM,
+            )
         )
 
     def _connect_clusters(self):
@@ -1166,7 +1343,7 @@ class _CassandraAccessor(bg_accessor.Accessor):
             session.default_timeout = self.__timeout
         return cluster, session
 
-    def _execute(self, session, *args, **kwargs):
+    def _execute(self, session, execution_request, **kwargs):
         """Wrapper for __session.execute_async()."""
         if self.__bulkimport:
             return []
@@ -1174,10 +1351,13 @@ class _CassandraAccessor(bg_accessor.Accessor):
         if self.__trace:
             kwargs["trace"] = True
 
+        args = execution_request.args()
+
         if args:
             log.debug(" ".join([str(arg) for arg in args]))
         if kwargs:
             log.debug(" ".join(["%s:%s " % (k, v) for k, v in kwargs.items()]))
+        execution_request.mark()
         result = session.execute(*args, **kwargs)
 
         if self.__trace:
@@ -1186,15 +1366,15 @@ class _CassandraAccessor(bg_accessor.Accessor):
                 log.debug("%s: %s" % (e.source_elapsed, str(e)))
         return result
 
-    def _execute_data(self, timer, *args, **kwargs):
+    def _execute_data(self, timer, execution_request, **kwargs):
         with timer.time():
-            return self._execute(self.__session_data, *args, **kwargs)
+            return self._execute(self.__session_data, execution_request, **kwargs)
 
-    def _execute_metadata(self, timer, *args, **kwargs):
+    def _execute_metadata(self, timer, execution_request, **kwargs):
         with timer.time():
-            return self._execute(self.__session_metadata, *args, **kwargs)
+            return self._execute(self.__session_metadata, execution_request, **kwargs)
 
-    def _execute_async(self, session, *args, **kwargs):
+    def _execute_async(self, session, execution_request, **kwargs):
         """Wrapper for __session.execute_async()."""
         if self.__bulkimport:
 
@@ -1207,11 +1387,13 @@ class _CassandraAccessor(bg_accessor.Accessor):
         if self.__trace:
             kwargs["trace"] = True
 
-        if args:
-            log.debug(" ".join([str(arg) for arg in args]))
+        if execution_request.params:
+            log.debug(" ".join([str(arg) for arg in execution_request.args()]))
         if kwargs:
             log.debug(" ".join(["%s:%s " % (k, v) for k, v in kwargs.items()]))
-        future = session.execute_async(*args, **kwargs)
+
+        execution_request.mark()
+        future = session.execute_async(*execution_request.args(), **kwargs)
 
         if self.__trace:
             trace = future.get_query_trace()
@@ -1219,28 +1401,29 @@ class _CassandraAccessor(bg_accessor.Accessor):
                 log.debug(e.source_elapsed, e.description)
         return future
 
-    def _execute_async_data(self, *args, **kwargs):
-        return self._execute_async(self.__session_data, *args, **kwargs)
+    def _execute_async_data(self, execution_request, **kwargs):
+        return self._execute_async(self.__session_data, execution_request, **kwargs)
 
-    def _execute_async_metadata(self, *args, **kwargs):
-        return self._execute_async(self.__session_metadata, *args, **kwargs)
+    def _execute_async_metadata(self, execution_request, **kwargs):
+        return self._execute_async(self.__session_metadata, execution_request, **kwargs)
 
-    def _execute_concurrent(self, session, statements_and_parameters, **kwargs):
+    def _execute_concurrent(self, session, execution_requests, **kwargs):
         """Wrapper for concurrent.execute_concurrent()."""
         if self.__bulkimport:
             return []
 
-        log.debug(statements_and_parameters)
+        log.debug(execution_requests)
 
         if not self.__trace:
+            args = [ec.args() for ec in execution_requests]
             return c_concurrent.execute_concurrent(
-                session, statements_and_parameters, **kwargs
+                session, args, **kwargs
             )
 
         query_results = []
-        for statement, params in statements_and_parameters:
+        for execution_request in execution_requests:
             try:
-                result = self._execute(session, statement, params, trace=True)
+                result = self._execute(session, execution_request, trace=True)
                 success = True
             except Exception as e:
                 if kwargs.get("raise_on_first_error") is True:
@@ -1250,11 +1433,11 @@ class _CassandraAccessor(bg_accessor.Accessor):
                 query_results.append((success, result))
         return query_results
 
-    def _execute_concurrent_data(self, *args, **kwargs):
-        return self._execute_concurrent(self.__session_data, *args, **kwargs)
+    def _execute_concurrent_data(self, execution_requests, **kwargs):
+        return self._execute_concurrent(self.__session_data, execution_requests, **kwargs)
 
-    def _execute_concurrent_metadata(self, *args, **kwargs):
-        return self._execute_concurrent(self.__session_metadata, *args, **kwargs)
+    def _execute_concurrent_metadata(self, execution_requests, **kwargs):
+        return self._execute_concurrent(self.__session_metadata, execution_requests, **kwargs)
 
     def create_metric(self, metric):
         """See bg_accessor.Accessor."""
@@ -1281,14 +1464,16 @@ class _CassandraAccessor(bg_accessor.Accessor):
         metadata_dict = metric.metadata.as_string_dict()
         queries.append(
             (
-                self.__insert_metric_statement,
-                [metric.name, parent_dir + "."] + components + padding,
+                self.__insert_metric_statement.with_param_list(
+                    [metric.name, parent_dir + "."] + components + padding
+                )
             )
         )
         queries.append(
             (
-                self.__insert_metrics_metadata_statement,
-                [metric.name, metric.id, metadata_dict],
+                self.__insert_metrics_metadata_statement.with_param_list(
+                    [metric.name, metric.id, metadata_dict]
+                )
             )
         )
 
@@ -1308,20 +1493,28 @@ class _CassandraAccessor(bg_accessor.Accessor):
         metadata_dict = updated_metadata.as_string_dict()
         self._execute_metadata(
             UPDATE_METRIC,
-            self.__update_metric_metadata_statement,
-            [metadata_dict, encoded_metric_name],
+            self.__update_metric_metadata_statement.with_param_list(
+                [metadata_dict, encoded_metric_name]
+            )
         )
 
     def delete_metric(self, name):
         """See bg_accessor.Accessor."""
         super(_CassandraAccessor, self).delete_metric(name)
-        self._execute_async_metadata(self.__delete_metric, [name])
-        self._execute_async_metadata(self.__delete_metric_metadata, [name])
+        self._execute_async_metadata(
+            self.__delete_metric.with_params(name)
+        )
+        self._execute_async_metadata(
+            self.__delete_metric_metadata.with_params(name)
+        )
 
     def delete_directory(self, directory):
         """See bg_accessor.Accessor."""
         super(_CassandraAccessor, self).delete_directory(directory)
-        self._execute_metadata(DELETE_DIRECTORY, self.__delete_directory, [directory])
+        self._execute_metadata(
+            DELETE_DIRECTORY_LATENCY,
+            self.__delete_directory.with_params(directory)
+        )
 
     def _create_parent_dirs_queries(self, components):
         queries = []
@@ -1337,8 +1530,9 @@ class _CassandraAccessor(bg_accessor.Accessor):
             padding = [c_query.UNSET_VALUE] * padding_len
             queries.append(
                 (
-                    self.__insert_directory_statement,
-                    [name, parent + DIRECTORY_SEPARATOR] + path_components + padding,
+                    self.__insert_directory_statement.with_param_list(
+                        [name, parent + DIRECTORY_SEPARATOR] + path_components + padding
+                    )
                 )
             )
             parent = name
@@ -1359,10 +1553,21 @@ class _CassandraAccessor(bg_accessor.Accessor):
             statement_str = (
                 "SELECT table_name FROM system_schema.tables WHERE keyspace_name = %s;"
             )
-            tables = [r[0] for r in self._execute(session, statement_str, (keyspace,))]
+
+            select_request = _CassandraExecutionRequest(
+                SELECT_TABLES_FROM_KEYSPACE,
+                statement_str,
+                keyspace)
+            tables = [r[0] for r in self._execute(session, select_request)]
 
             for table in tables:
-                self._execute(session, 'TRUNCATE "%s"."%s";' % (keyspace, table))
+                self._execute(
+                    session,
+                    _CassandraExecutionRequest(
+                        DROP_ALL_METRICS,
+                        'TRUNCATE "%s"."%s";' % (keyspace, table)
+                    )
+                )
 
         drop_all_metrics_in_keyspace(self.keyspace, self.__session_data)
         if self.metadata_enabled:
@@ -1394,14 +1599,14 @@ class _CassandraAccessor(bg_accessor.Accessor):
         time_end_ms = int(time_end) * 1000
         time_start_ms = max(time_end_ms - stage.duration_ms, time_start_ms)
 
-        statements_and_args = self._fetch_points_make_selects(
+        execution_requests = self._fetch_points_make_selects(
             metric.id, time_start_ms, time_end_ms, stage
         )
         # Note: it's unclear if this returns as soon as the first
         # query has been executed or not. If yes, consider using execute_async
         # directly.
         query_results = self._execute_concurrent_data(
-            statements_and_args, results_generator=True
+            execution_requests, results_generator=True
         )
 
         return bg_accessor.PointGrouper(
@@ -1442,7 +1647,8 @@ class _CassandraAccessor(bg_accessor.Accessor):
                 row_max_offset=row_max_offset,
             )
             if select is not None:
-                res.append(select)
+                statement, args = select
+                res.append(_CassandraExecutionRequest(FETCH_POINT, statement, *args))
 
         return res
 
@@ -1458,7 +1664,7 @@ class _CassandraAccessor(bg_accessor.Accessor):
         with READ_ON.time():
             log.debug("updating read_on for %s" % metric_name)
             self._execute_async_metadata(
-                self.__update_metric_read_on_metadata_statement, (metric_name,)
+                self.__update_metric_read_on_metadata_statement.with_params(metric_name)
             )
 
     def _select_metric(self, metric_name):
@@ -1466,9 +1672,9 @@ class _CassandraAccessor(bg_accessor.Accessor):
         encoded_metric_name = bg_metric.encode_metric_name(metric_name)
         result = list(
             self._execute_metadata(
-                SELECT_METRIC_METADATA,
-                self.__select_metric_metadata_statement,
-                (encoded_metric_name,))
+                SELECT_METRIC_METADATA_LATENCY,
+                self.__select_metric_metadata_statement.with_params(encoded_metric_name)
+            )
         )
         if not result:
             return None
@@ -1502,8 +1708,12 @@ class _CassandraAccessor(bg_accessor.Accessor):
         result = list(
             self._execute_metadata(
                 HAS_DIRECTORY,
-                self.__select_directory_statement,
-                (encoded_directory,))
+                _CassandraExecutionRequest(
+                    SELECT_DIRECTORY,
+                    self.__select_directory_statement,
+                    encoded_directory
+                )
+            )
         )
         return bool(result)
 
@@ -1521,10 +1731,10 @@ class _CassandraAccessor(bg_accessor.Accessor):
                         for metric_name in metric_names]
         metric_names = [bg_metric.encode_metric_name(metric_name) for metric_name in metric_names]
 
-        statements_with_params = [self._make_select_metric_statement(metric_name)
-                                  for metric_name in metric_names]
+        execution_requests = [self._make_select_metric_execution_request(metric_name)
+                              for metric_name in metric_names]
 
-        results = self._select_metrics(statements_with_params)
+        results = self._select_metrics(execution_requests)
 
         metrics = []
         for (success, result) in results:
@@ -1537,12 +1747,12 @@ class _CassandraAccessor(bg_accessor.Accessor):
                     metrics.append(metric)
         return metrics
 
-    def _make_select_metric_statement(self, metric_name):
+    def _make_select_metric_execution_request(self, metric_name):
         encoded_metric_name = bg_metric.encode_metric_name(metric_name)
-        return self.__select_metric_metadata_statement, (encoded_metric_name,)
+        return self.__select_metric_metadata_statement.with_params(encoded_metric_name)
 
-    def _select_metrics(self, statements_with_params):
-        return self._execute_concurrent_metadata(statements_with_params)
+    def _select_metrics(self, execution_requests):
+        return self._execute_concurrent_metadata(execution_requests)
 
     def get_metric(self, metric_name):
         """See bg_accessor.Accessor."""
@@ -1595,6 +1805,7 @@ class _CassandraAccessor(bg_accessor.Accessor):
                 % (len(components), _COMPONENTS_MAX_LEN)
             )
 
+        counter = None
         if self.__glob_parser.is_fully_defined(components):
             # When the glob is a fully defined metric, we can take a shortcut.
             # `glob` can't be used directly because, for example a.{b} would be a.b.
@@ -1602,38 +1813,42 @@ class _CassandraAccessor(bg_accessor.Accessor):
             # are combinations of fully defined paths.
             if table == "metrics":
                 query = self.__select_metric_statement
+                counter = SELECT_METRIC
             else:
                 query = self.__select_directory_statement
+                counter = SELECT_DIRECTORY
             path = DIRECTORY_SEPARATOR.join([c[0] for c in components])
             queries = [query.bind([path])]
         else:
             queries = self.metadata_query_generator.generate_queries(table, components)
+            counter = SELECT
 
-        statements_with_params = []
+        execution_requests = []
         for query in queries:
             if isinstance(query, six.string_types):
-                statement = c_query.SimpleStatement(
-                    query, consistency_level=self._meta_read_consistency
+                execution_request = _CassandraExecutionRequest(
+                    counter,
+                    c_query.SimpleStatement(query, consistency_level=self._meta_read_consistency)
                 )
             else:
-                statement = query
-            statements_with_params.append((statement, ()))
+                execution_request = _CassandraExecutionRequest(counter, query)
+            execution_requests.append(execution_request)
 
         if self.cache:
             # As queries can be statements, we use the string representation
             # (which always contains the query and the parameters).
             # WARNING: With the current code PrepareStatement would not be cached.
             keys_to_queries = {
-                self.__query_key(*sp): sp for sp in statements_with_params
+                self.__query_key(ec.statement, ec.params): ec for ec in execution_requests
             }
             cached_results = self.cache.get_many(keys_to_queries.keys())
             for key in cached_results:
-                statements_with_params.remove(keys_to_queries[key])
+                execution_requests.remove(keys_to_queries[key])
         else:
             cached_results = {}
 
         query_results = self._execute_concurrent_metadata(
-            statements_with_params,
+            execution_requests,
             concurrency=self.max_concurrent_queries_per_pattern,
             results_generator=True,
             raise_on_first_error=True,
@@ -1709,7 +1924,7 @@ class _CassandraAccessor(bg_accessor.Accessor):
         if on_done:
             count_down = _CountDown(count=len(datapoints), on_zero=on_done)
 
-        statements = collections.defaultdict(list)
+        execution_requests = collections.defaultdict(list)
         for timestamp, value, count, stage in datapoints:
             timestamp_ms = int(timestamp) * 1000
             time_offset_ms = timestamp_ms % _row_size_ms(stage)
@@ -1727,26 +1942,30 @@ class _CassandraAccessor(bg_accessor.Accessor):
 
             # We group by table/partition.
             key = (stage, time_start_ms)
-            statements[key].append((statement, args))
+            execution_requests[key].append(
+                _CassandraExecutionRequest(INSERT_DOWNSAMPLED_POINTS, statement, *args)
+            )
 
-        for statements_and_args in statements.values():
-            if len(statements_and_args) == 1:
-                statement, args = statements_and_args[0]
+        for execution_requests_for_partition in execution_requests.values():
+            execution_request = None
+            if len(execution_requests_for_partition) == 1:
+                execution_request = execution_requests_for_partition[0]
                 count = 1
             else:
                 batch = c_query.BatchStatement(
                     consistency_level=self._data_write_consistency,
                     batch_type=c_query.BatchType.UNLOGGED,
                 )
-                for statement, args in statements_and_args:
-                    if statement is not None:
-                        batch.add(statement, args)
-                statement = batch
-                args = None
-                count = len(statements_and_args)
+                for execution_request in execution_requests_for_partition:
+                    if execution_request is not None:
+                        batch.add(execution_request.statement, execution_request.params)
+                        execution_request = _CassandraExecutionRequest(
+                            INSERT_DOWNSAMPLED_POINTS_BATCH, batch
+                        )
+                count = len(execution_requests_for_partition)
 
             future = self._execute_async(
-                session=self.__session_data, query=statement, parameters=args
+                session=self.__session_data, execution_request=execution_request
             )
             if count_down:
                 if count > 1:
@@ -1799,7 +2018,10 @@ class _CassandraAccessor(bg_accessor.Accessor):
                 query = cql % {"keyspace": self.keyspace_metadata}
                 schema += query + "\n\n"
                 if not dry_run:
-                    self._execute_metadata(SYNCDB_METADATA, query)
+                    self._execute_metadata(
+                        SYNCDB_METADATA,
+                        _CassandraExecutionRequest(METADATA_SCHEMA_UPDATE, query)
+                    )
 
         self.__cluster_data.refresh_schema_metadata()
         keyspaces = self.__cluster_data.metadata.keyspaces.keys()
@@ -1831,7 +2053,10 @@ class _CassandraAccessor(bg_accessor.Accessor):
                 query = self.__lazy_statements._create_datapoints_table_stmt(stage)
                 schema += query + "\n\n"
                 if not dry_run:
-                    self._execute_data(SYNCDB_DATA, query)
+                    self._execute_data(
+                        SYNCDB_DATA,
+                        _CassandraExecutionRequest(SYNCDB, query)
+                    )
 
         if not was_connected:
             self.shutdown()
@@ -1857,7 +2082,7 @@ class _CassandraAccessor(bg_accessor.Accessor):
 
             # Update Cassandra.
             self._execute_async_metadata(
-                self.__touch_metrics_metadata_statement, (metric.name,)
+                self.__touch_metrics_metadata_statement.with_params(metric.name)
             )
 
     def map(
@@ -1898,7 +2123,12 @@ class _CassandraAccessor(bg_accessor.Accessor):
         while token < stop_token:
             # Schedule read first.
             future = self._execute_async_metadata(
-                select, (int(token),), DEFAULT_TIMEOUT_QUERY_UTIL
+                _CassandraExecutionRequest(
+                    MAP_ITERATION,
+                    select,
+                    int(token)
+                ),
+                timeout=DEFAULT_TIMEOUT_QUERY_UTIL
             )
 
             # Then execute callback for the *previous* result while C* is
@@ -2017,7 +2247,11 @@ class _CassandraAccessor(bg_accessor.Accessor):
                 name, next_token = row
                 parent_dir = name.rpartition(".")[0]
                 if parent_dir:
-                    yield has_directory_query, (parent_dir,)
+                    yield _CassandraExecutionRequest(
+                        REPAIR_DIRECTORIES_TO_CHECK,
+                        has_directory_query,
+                        parent_dir
+                    )
 
         def directories_to_create(result):
             for response in result:
@@ -2035,14 +2269,22 @@ class _CassandraAccessor(bg_accessor.Accessor):
                 queries = self._create_parent_dirs_queries(components)
                 for query in queries:
                     PM_REPAIRED_DIRECTORIES.inc()
-                    yield query
+                    yield _CassandraExecutionRequest(
+                        REPAIR_DIRECTORIES_TO_CREATE,
+                        query
+                    )
 
         log.info("Start creating missing directories")
         token = start_token
         while token < stop_token:
             result = self._execute_metadata(
                 REPAIR_MISSING_DIR,
-                dir_query, (int(token),), DEFAULT_TIMEOUT_QUERY_UTIL
+                _CassandraExecutionRequest(
+                    REPAIR_MISSING_DIR_COUNT,
+                    dir_query,
+                    int(token)
+                ),
+                timeout=DEFAULT_TIMEOUT_QUERY_UTIL
             )
             if len(result.current_rows) == 0:
                 break
@@ -2099,7 +2341,11 @@ class _CassandraAccessor(bg_accessor.Accessor):
             for row in result:
                 name, next_token = row
                 if name:
-                    yield (has_metric_query, (name + DIRECTORY_SEPARATOR + "%",))
+                    yield _CassandraExecutionRequest(
+                        CLEAN_DIRECTORIES_TO_CHECK,
+                        has_metric_query,
+                        name + DIRECTORY_SEPARATOR + "%"
+                    )
 
         def directories_to_remove(result):
             for response in result:
@@ -2113,15 +2359,25 @@ class _CassandraAccessor(bg_accessor.Accessor):
                 dir_name = str(dir_name).rpartition(".")[0]
                 log.info("Scheduling delete for empty dir '%s'" % dir_name)
                 PM_DELETED_DIRECTORIES.inc()
-                yield delete_empty_dir_stm, (dir_name,)
+                yield _CassandraExecutionRequest(
+                    CLEAN_DIRECTORIES_TO_REMOVE,
+                    delete_empty_dir_stm,
+                    dir_name
+                )
 
         log.info("Starting cleanup of empty dir")
         token = start_token
         while token < stop_token:
             result = self._execute_metadata(
                 CLEAN_EMPTY_DIR,
-                dir_query, (int(token),), DEFAULT_TIMEOUT_QUERY_UTIL
+                _CassandraExecutionRequest(
+                    CLEAN,
+                    dir_query,
+                    int(token)
+                ),
+                timeout=DEFAULT_TIMEOUT_QUERY_UTIL
             )
+
             if len(result.current_rows) == 0:
                 break
 
@@ -2223,26 +2479,35 @@ class _CassandraAccessor(bg_accessor.Accessor):
         log.info("Cleaning with cutoff time %d", cutoff)
 
         # statements
-        select = self._prepare_background_request_on_index(
-            'SELECT name, token(name) FROM "%s".metrics_metadata'
-            " WHERE updated_on <= maxTimeuuid(%d) and token(name) > ? LIMIT %d ;"
-            % (self.keyspace_metadata, cutoff, DEFAULT_MAX_BATCH_UTIL)
+        select = _CassandraExecutionRequest(
+            CLEAN_EXPIRED_METRICS_SELECT,
+            self._prepare_background_request_on_index(
+                'SELECT name, token(name) FROM "%s".metrics_metadata'
+                " WHERE updated_on <= maxTimeuuid(%d) and token(name) > ? LIMIT %d ;"
+                % (self.keyspace_metadata, cutoff, DEFAULT_MAX_BATCH_UTIL)
+            )
         )
 
-        delete = self._prepare_background_request(
-            'DELETE FROM "%s".metrics WHERE name = ? ;' % (self.keyspace_metadata)
+        delete = _CassandraExecutionRequest(
+            CLEAN_EXPIRED_METRICS_DELETE,
+            self._prepare_background_request(
+                'DELETE FROM "%s".metrics WHERE name = ? ;' % (self.keyspace_metadata)
+            )
         )
-        delete_metadata = self._prepare_background_request(
-            'DELETE FROM "%s".metrics_metadata WHERE name = ? ;'
-            % (self.keyspace_metadata)
+        delete_metadata = _CassandraExecutionRequest(
+            CLEAN_EXPIRED_METRICS_DELETE_METADATA,
+            self._prepare_background_request(
+                'DELETE FROM "%s".metrics_metadata WHERE name = ? ;'
+                % (self.keyspace_metadata)
+            )
         )
 
         def run(rows):
             for name, _ in rows:
                 log.info("Scheduling delete for obsolete metric %s", name)
                 PM_EXPIRED_METRICS.inc()
-                yield (delete, (name,))
-                yield (delete_metadata, (name,))
+                yield (delete.with_params(name))
+                yield (delete_metadata.with_params(name))
 
         ignored_errors = 0
         token = start_token
@@ -2250,7 +2515,8 @@ class _CassandraAccessor(bg_accessor.Accessor):
             try:
                 rows = self._execute_metadata(
                     CLEAN_EXPIRED_METRICS,
-                    select, (int(token),), DEFAULT_TIMEOUT_QUERY_UTIL
+                    select.with_params(int(token)),
+                    timeout=DEFAULT_TIMEOUT_QUERY_UTIL
                 )
 
                 # Empty results means that we've reached the end.

--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -186,10 +186,6 @@ REPAIR_DIRECTORIES_TO_CREATE = prometheus_client.Counter(
 )
 
 
-UPDATED_ON = prometheus_client.Summary(
-    "bg_cassandra_updated_on_latency_seconds",
-    "create latency in seconds"
-)
 READ_ON = prometheus_client.Summary(
     "bg_cassandra_read_on_latency_seconds",
     "create latency in seconds"
@@ -2063,7 +2059,6 @@ class _CassandraAccessor(bg_accessor.Accessor):
             self.shutdown()
         return schema
 
-    @UPDATED_ON.time()
     def touch_metric(self, metric):
         """See the real Accessor for a description."""
         super(_CassandraAccessor, self).touch_metric(metric)

--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -37,6 +37,7 @@ from cassandra import marshal as c_marshal
 from cassandra import murmur3
 from cassandra import policies as c_policies
 from cassandra import query as c_query
+from future.utils import raise_with_traceback
 
 from biggraphite import accessor as bg_accessor
 from biggraphite import glob_utils as bg_glob
@@ -2434,7 +2435,7 @@ class _CassandraAccessor(bg_accessor.Accessor):
             log.exception("Failed to clean metrics.")
 
         if first_exception is not None:
-            raise first_exception
+            raise_with_traceback(first_exception)
 
     def _prepare_background_request(self, query_str):
         select = self.__session_metadata.prepare(query_str)


### PR DESCRIPTION
* For synchronous queries, use of a timer is mandatory (by API design).
* A query wrapper allows to count any query (synchronous or asynchronous).
