### PR TITLE
Improve observability on metric creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Breaking changes
+- the previous metric `bg_creates` becomes `bg_creates_enqueued` for Cassandra driver
+
 ### Improved
-- —
+- improved observability on metric creation
 
 ### Fixed
 - —

--- a/biggraphite/plugins/carbon.py
+++ b/biggraphite/plugins/carbon.py
@@ -56,7 +56,13 @@ EXISTS_TIME = prometheus_client.Summary(
     "bg_exists_latency_seconds", "create latency in seconds"
 )
 
-CREATES = prometheus_client.Counter("bg_creates", "metric creations")
+CREATES_ENQUEUED = prometheus_client.Counter(
+    "bg_creates_enqueued", "metrics scheduled for creation"
+)
+
+CREATES_DEQUEUED = prometheus_client.Counter(
+    "bg_creates_dequeued", "metrics created in database"
+)
 
 
 class BigGraphiteDatabase(database.TimeSeriesDatabase):
@@ -271,6 +277,7 @@ class BigGraphiteDatabase(database.TimeSeriesDatabase):
           metric_name: the original, un-encoded metric name
         """
         self._metricsToCreate.put((metric, metric_name))
+        CREATES_ENQUEUED.inc()
 
     def _createMetrics(self):
         # We create metrics in a separate thread because this is potentially
@@ -315,7 +322,7 @@ class BigGraphiteDatabase(database.TimeSeriesDatabase):
 
         self.cache.create_metric(metric)
         self.tag(metric_name)
-        CREATES.inc()
+        CREATES_DEQUEUED.inc()
 
 
 class MultiDatabase(database.TimeSeriesDatabase):


### PR DESCRIPTION
The metric creation process is asynchronous, metrics scheduled to be created are added to a queue and a thread process it to effectively create them in database.

This PR aims to monitor the enqueuing rate. The dequeuing rate where already monitored via `bg_creates` which I renamed `bg_creates_dequeued`.