### PR TITLE
Improve observability on metric creation - fixing issue introduced in the previous commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Breaking changes
-- the previous metric `bg_creates` becomes `bg_creates_enqueued` for Cassandra driver
-
 ### Improved
 - improved observability on metric creation
 
@@ -34,7 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [0.13.10] - 2018-10-08
 
 ### Improved
-- cassandra accessor observability: add metrics on query usage 
+- cassandra accessor observability: add metrics on query usage
 
 ## [0.13.9] - 2018-08-28
 

--- a/biggraphite/plugins/carbon.py
+++ b/biggraphite/plugins/carbon.py
@@ -56,6 +56,10 @@ EXISTS_TIME = prometheus_client.Summary(
     "bg_exists_latency_seconds", "create latency in seconds"
 )
 
+CREATES = prometheus_client.Counter(
+    "bg_creates", "metric creations"
+)
+
 CREATES_ENQUEUED = prometheus_client.Counter(
     "bg_creates_enqueued", "metrics scheduled for creation"
 )
@@ -305,6 +309,8 @@ class BigGraphiteDatabase(database.TimeSeriesDatabase):
         except queue.Empty:
             return
 
+        CREATES_DEQUEUED.inc()
+
         existing_metric = self.accessor.get_metric(metric.name)
 
         if metric == existing_metric:
@@ -322,7 +328,7 @@ class BigGraphiteDatabase(database.TimeSeriesDatabase):
 
         self.cache.create_metric(metric)
         self.tag(metric_name)
-        CREATES_DEQUEUED.inc()
+        CREATES.inc()
 
 
 class MultiDatabase(database.TimeSeriesDatabase):


### PR DESCRIPTION
I wrongly changed the "bg_creates" metric in PR #473. This PR restores "bg_creates" and increments the new metric "bg_creates_dequeued" at the right place.