### PR TITLE
Upgrade Lucene to 7.1.0 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- CVE-2017-12629 on graphiteindex (upgrade to Lucene 7.1.0)
+
 ## [0.14.1] - 2018-10-15
 
 ### Improved

--- a/tools/graphiteindex/pom.xml
+++ b/tools/graphiteindex/pom.xml
@@ -41,7 +41,7 @@
   </description>
 
   <properties>
-    <lucene.version>6.6.1</lucene.version>
+    <lucene.version>7.1.0</lucene.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Fixes CVE-2017-12629
See: https://nvd.nist.gov/vuln/detail/CVE-2017-12629
