### PR TITLE
Fix list index out of range in _get_metrics when the metric doesn't exists

### DIFF
--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -1741,8 +1741,7 @@ class _CassandraAccessor(bg_accessor.Accessor):
         for (success, result) in results:
             if not success:
                 raise CassandraError("Failed to concurrently get metrics", result)
-            if result[0] is not None:
-                row = result[0]
+            for row in result:
                 metric = self._bind_metric(row)
                 if metric is not None:
                     metrics.append(metric)

--- a/tests/drivers/base_test_metadata.py
+++ b/tests/drivers/base_test_metadata.py
@@ -400,3 +400,7 @@ class BaseTestAccessorMetadata(object):
         self.accessor.touch_metric(metric)
         self.accessor.create_metric(metric)
         self.accessor.touch_metric(metric)
+
+    def test_get_metric_unknown(self):
+        unknown_metric_name = 'this.metric.is.unknown'
+        self.assertEqual(self.accessor.get_metric(unknown_metric_name), None)


### PR DESCRIPTION
This fix aims to prevent a "list index out of range" exception to be raised when the metric name doesn't exists in database:

```
Unhandled Error
        Traceback (most recent call last):
          File "/opt/graphite/pypy/site-packages/twisted/
            result = inContext.theWork()
          File "/opt/graphite/pypy/site-packages/twisted/
            inContext.theWork = lambda: context.call(ctx, 
          File "/opt/graphite/pypy/site-packages/twisted/
            return self.currentContext().callWithContext(
          File "/opt/graphite/pypy/site-packages/twisted/
            return func(*args,**kw)
        --- <exception caught here> ---
          File "/opt/graphite/pypy/site-packages/biggraphite/
            self._createOneMetric()
          File "/opt/graphite/pypy/site-packages/biggraphite/
            existing_metric = self.accessor.get_metric(
          File "/opt/graphite/pypy/site-packages/biggraphite/
            return next(iter(
          File "/opt/graphite/pypy/site-packages/biggraphite/
            if result[0] is not None:
          File "/opt/graphite/pypy/site-packages/cassandra/
            return self._current_rows[i]
        exceptions.IndexError: list index out of range
```