### PR TITLE
Share MetricMetadata objects as much as possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Improved
+
+- reduced number of metadata objects handled by biggraphite
+
 ## [0.14.5] - 2018-12-13
 
 ### Fixed

--- a/biggraphite/cli/command_write.py
+++ b/biggraphite/cli/command_write.py
@@ -76,7 +76,7 @@ class CommandWrite(command.BaseCommand):
         metric = accessor.get_metric(opts.metric)
         if not metric:
             print("Metric '%s' was not found and will be created" % opts.metric)
-            metadata = bg_metric.MetricMetadata(
+            metadata = bg_metric.MetricMetadata.create(
                 aggregator=bg_metric.Aggregator.from_config_name(opts.aggregator),
                 retention=bg_metric.Retention.from_string(opts.retention),
                 carbon_xfilesfactor=opts.x_files_factor,

--- a/biggraphite/cli/import_whisper.py
+++ b/biggraphite/cli/import_whisper.py
@@ -89,7 +89,7 @@ class _Worker(object):
             ]
         )
         aggregator = bg_metric.Aggregator.from_carbon_name(info["aggregationMethod"])
-        return bg_metric.MetricMetadata(
+        return bg_metric.MetricMetadata.create(
             aggregator=aggregator,
             retention=retentions,
             carbon_xfilesfactor=info["xFilesFactor"],

--- a/biggraphite/cli/web/namespaces/biggraphite.py
+++ b/biggraphite/cli/web/namespaces/biggraphite.py
@@ -76,7 +76,7 @@ class MetricResource(rp.Resource):
         if not context.accessor.has_metric(name):
             return "Unknown metric: '%s'" % name, 404
         payload = request.json
-        metadata = bg_metric.MetricMetadata(
+        metadata = bg_metric.MetricMetadata.create(
             aggregator=bg_metric.Aggregator.from_config_name(payload["aggregator"]),
             retention=bg_metric.Retention.from_string(payload["retention"]),
             carbon_xfilesfactor=payload["carbon_xfilesfactor"],

--- a/biggraphite/metadata_cache.py
+++ b/biggraphite/metadata_cache.py
@@ -333,12 +333,15 @@ class MemoryCache(MetadataCache):
 
     def stats(self):
         """Current stats about the cache the cache."""
-        return {
-            "size": self.__cache.currsize,
-            "maxsize": self.__cache.maxsize,
-            "hits": self._hits._value.get(),
-            "miss": self._misses._value.get(),
-        }
+        if self.__cache:
+            return {
+                    "size": self.__cache.currsize,
+                    "maxsize": self.__cache.maxsize,
+                    "hits": self._hits._value.get(),
+                    "miss": self._misses._value.get(),
+                }
+        else:
+            return super(MemoryCache, self).stats()
 
 
 class DiskCache(MetadataCache):

--- a/biggraphite/plugins/carbon.py
+++ b/biggraphite/plugins/carbon.py
@@ -187,7 +187,7 @@ class BigGraphiteDatabase(database.TimeSeriesDatabase):
         orig_metric_name = metric_name
         metric_name = self.encode(metric_name)
 
-        metadata = bg_metric.MetricMetadata(
+        metadata = bg_metric.MetricMetadata.create(
             aggregator=bg_metric.Aggregator.from_carbon_name(aggregation_method),
             retention=bg_metric.Retention.from_carbon(retentions),
             carbon_xfilesfactor=xfilesfactor,

--- a/biggraphite/plugins/graphite.py
+++ b/biggraphite/plugins/graphite.py
@@ -95,7 +95,7 @@ class Reader(BaseReader):
         if self._metric is not None:
             return self._metric.metadata
         else:
-            return bg_metric.MetricMetadata()
+            return bg_metric.MetricMetadata.create()
 
     def __get_time_info(self, start_time, end_time, now, shift=False):
         """Constrain the provided range in an aligned interval within retention."""

--- a/tests/cli/test_command_delete.py
+++ b/tests/cli/test_command_delete.py
@@ -34,7 +34,7 @@ class TestCommandDelete(bg_test_utils.TestCaseWithFakeAccessor):
         cmd.add_arguments(parser)
 
         name = "foo.bar"
-        metadata = bg_metric.MetricMetadata(
+        metadata = bg_metric.MetricMetadata.create(
             retention=bg_metric.Retention.from_string("1440*60s")
         )
 

--- a/tests/cli/test_command_du.py
+++ b/tests/cli/test_command_du.py
@@ -30,7 +30,7 @@ from tests import test_utils as bg_test_utils
 class TestCommandDu(bg_test_utils.TestCaseWithFakeAccessor):
 
     metrics = ["metric1", "metric2"]
-    metadata = MetricMetadata(retention=Retention.from_string("1440*60s"))
+    metadata = MetricMetadata.create(retention=Retention.from_string("1440*60s"))
 
     @patch("sys.stdout", new_callable=StringIO)
     def get_output(self, args, mock_stdout):

--- a/tests/cli/test_command_graphite_web.py
+++ b/tests/cli/test_command_graphite_web.py
@@ -26,7 +26,7 @@ from tests import test_utils as bg_test_utils
 class TestCommandGraphiteWeb(bg_test_utils.TestCaseWithFakeAccessor):
     def test_run(self):
         name = "foo.bar"
-        metadata = bg_metric.MetricMetadata(
+        metadata = bg_metric.MetricMetadata.create(
             retention=bg_metric.Retention.from_string("1440*60s")
         )
         self.accessor.create_metric(bg_test_utils.make_metric(name, metadata))

--- a/tests/cli/test_command_list.py
+++ b/tests/cli/test_command_list.py
@@ -34,7 +34,7 @@ class TestCommandList(bg_test_utils.TestCaseWithFakeAccessor):
         cmd.add_arguments(parser)
 
         name = "foo.bar"
-        metadata = bg_metric.MetricMetadata(
+        metadata = bg_metric.MetricMetadata.create(
             retention=bg_metric.Retention.from_string("1440*60s")
         )
 

--- a/tests/cli/test_command_read.py
+++ b/tests/cli/test_command_read.py
@@ -26,7 +26,7 @@ from tests import test_utils as bg_test_utils
 class TestCommandRead(bg_test_utils.TestCaseWithFakeAccessor):
     def test_run(self):
         name = "foo.bar"
-        metadata = bg_metric.MetricMetadata(
+        metadata = bg_metric.MetricMetadata.create(
             retention=bg_metric.Retention.from_string("1440*60s")
         )
         self.accessor.create_metric(bg_test_utils.make_metric(name, metadata))

--- a/tests/cli/test_command_stats.py
+++ b/tests/cli/test_command_stats.py
@@ -30,7 +30,7 @@ from tests import test_utils as bg_test_utils
 class TestCommandStats(bg_test_utils.TestCaseWithFakeAccessor):
 
     metrics = ["metric1", "metric2"]
-    metadata = MetricMetadata(retention=Retention.from_string("1440*60s"))
+    metadata = MetricMetadata.create(retention=Retention.from_string("1440*60s"))
 
     @patch("sys.stdout", new_callable=StringIO)
     def get_output(self, args, mock_stdout):

--- a/tests/cli/test_command_web.py
+++ b/tests/cli/test_command_web.py
@@ -15,9 +15,8 @@
 from __future__ import print_function
 
 import argparse
+import mock
 import unittest
-
-import prometheus_client
 
 try:
     import gourde
@@ -33,13 +32,9 @@ from tests import test_utils as bg_test_utils
 class TestCommandWeb(bg_test_utils.TestCaseWithFakeAccessor):
     def tearDown(self):
         super(TestCommandWeb, self).tearDown()
-        # Reset the registry to make sure we can instantiate the app again.
-        # TODO: Try to use mock instead to do that.
-        prometheus_client.REGISTRY = prometheus_client.core.CollectorRegistry(
-            auto_describe=True
-        )
 
-    def test_run(self):
+    @mock.patch('prometheus_client.REGISTRY')
+    def test_run(self, prometheus_registry_mock):
         cmd = command_web.CommandWeb()
 
         parser = argparse.ArgumentParser()

--- a/tests/drivers/base_test_metadata.py
+++ b/tests/drivers/base_test_metadata.py
@@ -256,7 +256,7 @@ class BaseTestAccessorMetadata(object):
             "retention": bg_metric.Retention.from_string("60*1s:60*60s"),
             "carbon_xfilesfactor": 0.3,
         }
-        metadata = bg_metric.MetricMetadata(**meta_dict)
+        metadata = bg_metric.MetricMetadata.create(**meta_dict)
         metric_name = "a.b.c.d.e.f"
         self.accessor.create_metric(bg_test_utils.make_metric(metric_name, metadata))
         self.flush()
@@ -270,7 +270,7 @@ class BaseTestAccessorMetadata(object):
             "retention": bg_metric.Retention.from_string("30*1s:120*30s"),
             "carbon_xfilesfactor": 0.5,
         }
-        updated_metadata = bg_metric.MetricMetadata(**updated_meta_dict)
+        updated_metadata = bg_metric.MetricMetadata.create(**updated_meta_dict)
         # Setting a known metric name should work
         self.accessor.update_metric(metric_name, updated_metadata)
         updated_metric = self.accessor.get_metric(metric_name)

--- a/tests/drivers/test_drivers_delayed_writer.py
+++ b/tests/drivers/test_drivers_delayed_writer.py
@@ -40,7 +40,7 @@ class TestDelayedWriter(test_utils.TestCaseWithFakeAccessor):
         self.stage_0 = retention.stages[0]
         self.stage_1 = retention.stages[1]
 
-        metadata = bg_metric.MetricMetadata(
+        metadata = bg_metric.MetricMetadata.create(
             aggregator=bg_metric.Aggregator.average, retention=retention
         )
         self.metric = test_utils.make_metric(self.METRIC_NAME, metadata=metadata)

--- a/tests/drivers/test_drivers_downsampling.py
+++ b/tests/drivers/test_drivers_downsampling.py
@@ -44,13 +44,13 @@ class TestDownsampler(unittest.TestCase):
         self.stage_0 = retention.stages[0]
         self.stage_1 = retention.stages[1]
         uid = uuid.uuid4()
-        metric_metadata = bg_metric.MetricMetadata(
+        metric_metadata = bg_metric.MetricMetadata.create(
             aggregator=bg_metric.Aggregator.total, retention=retention
         )
         self.metric_sum = bg_metric.Metric(self.METRIC_NAME_SUM, uid, metric_metadata)
 
         uid = uuid.uuid4()
-        metric_metadata = bg_metric.MetricMetadata(
+        metric_metadata = bg_metric.MetricMetadata.create(
             aggregator=bg_metric.Aggregator.average, retention=retention
         )
         self.metric_avg = bg_metric.Metric(self.METRIC_NAME_AVG, uid, metric_metadata)

--- a/tests/drivers/test_elasticsearch.py
+++ b/tests/drivers/test_elasticsearch.py
@@ -72,7 +72,7 @@ class DocumentFromMetricTest(unittest.TestCase):
         retention_str = "42*1s:43*60s"
         retention = Retention.from_string(retention_str)
         carbon_xfilesfactor = 0.5
-        metadata = MetricMetadata(aggregator, retention, carbon_xfilesfactor)
+        metadata = MetricMetadata.create(aggregator, retention, carbon_xfilesfactor)
         metric = bg_metric.Metric(
             metric_name,
             metric_id,
@@ -298,7 +298,7 @@ def _create_default_metadata():
     retention_str = "42*1s:43*60s"
     retention = Retention.from_string(retention_str)
     carbon_xfilesfactor = 0.5
-    metadata = MetricMetadata(aggregator, retention, carbon_xfilesfactor)
+    metadata = MetricMetadata.create(aggregator, retention, carbon_xfilesfactor)
     return metadata
 
 
@@ -430,14 +430,14 @@ class TestAccessorWithElasticsearch(
 
     def test_update_metric_should_update_metric_metadata(self):
         metric_name = "test_update_metric_should_update_metric_metadata.a.b.c"
-        initial_metadata = MetricMetadata(
+        initial_metadata = MetricMetadata.create(
             aggregator=Aggregator.total,
             retention=Retention.from_string("42*1s"),
             carbon_xfilesfactor=0.5,
         )
         create_date = datetime.datetime(2014, 1, 1)
         update_date = datetime.datetime(2018, 1, 1)
-        new_metadata = MetricMetadata(
+        new_metadata = MetricMetadata.create(
             aggregator=Aggregator.average,
             retention=Retention.from_string("43*100s"),
             carbon_xfilesfactor=0.25,

--- a/tests/drivers/test_hybrid.py
+++ b/tests/drivers/test_hybrid.py
@@ -22,7 +22,7 @@ from biggraphite import metric as bg_metric
 from biggraphite.drivers import hybrid
 
 DEFAULT_METRIC_NAME = "foo.bar"
-DEFAULT_METADATA = bg_metric.MetricMetadata()
+DEFAULT_METADATA = bg_metric.MetricMetadata.create()
 DEFAULT_METRIC = bg_metric.Metric(DEFAULT_METRIC_NAME, "id", DEFAULT_METADATA)
 
 DEFAULT_GLOB = "foo.bar.**"

--- a/tests/drivers/test_memory.py
+++ b/tests/drivers/test_memory.py
@@ -71,5 +71,5 @@ def _create_default_metadata():
     retention_str = "42*1s:43*60s"
     retention = Retention.from_string(retention_str)
     carbon_xfilesfactor = 0.5
-    metadata = MetricMetadata(aggregator, retention, carbon_xfilesfactor)
+    metadata = MetricMetadata.create(aggregator, retention, carbon_xfilesfactor)
     return metadata

--- a/tests/plugins/test_carbon.py
+++ b/tests/plugins/test_carbon.py
@@ -109,8 +109,9 @@ class TestCarbonDatabase(bg_test_utils.TestCaseWithFakeAccessor):
         self.assertTrue(self._plugin.exists(metric_name))
 
         # See if we can update.
-        metric = bg_test_utils.make_metric(metric_name)
-        metric.metadata.retention = bg_metric.Retention([bg_metric.Stage(1, 1)])
+        metric = bg_test_utils.make_metric(
+            metric_name, retention=bg_metric.Retention([bg_metric.Stage(1, 1)])
+        )
         self._plugin._createAsyncOrig(metric, metric_name)
         self._plugin._createOneMetric()
         retention = self._plugin.getMetadata(metric_name, "retention")

--- a/tests/plugins/test_graphite.py
+++ b/tests/plugins/test_graphite.py
@@ -97,9 +97,8 @@ class TestReader(bg_test_utils.TestCaseWithFakeAccessor):
 
     def test_carbon_protocol_read(self):
         metric_name = "fake.name"
-        metric = bg_test_utils.make_metric(_METRIC_NAME)
         # Custom aggregator to make sure all goes right.
-        metric.metadata.aggregator = bg_metric.Aggregator.minimum
+        metric = bg_test_utils.make_metric(_METRIC_NAME, aggregator=bg_metric.Aggregator.minimum)
         self.accessor.create_metric(metric)
         self.accessor.flush()
         self.reader = bg_graphite.Reader(

--- a/tests/test_glob_utils.py
+++ b/tests/test_glob_utils.py
@@ -256,7 +256,8 @@ class TestGlobUtils(bg_test_utils.TestCaseWithFakeAccessor):
 class TestGraphiteGlobResult(unittest.TestCase):
 
     def test_GlobMetricResult_be_built_from_a_metric(self):
-        metric = bg_metric.Metric(name="foo.bar", id="0", metadata=bg_metric.MetricMetadata())
+        metric = bg_metric.Metric(
+            name="foo.bar", id="0", metadata=bg_metric.MetricMetadata.create())
 
         metric_result = bg_glob.GlobMetricResult.from_value(metric)
 
@@ -264,7 +265,8 @@ class TestGraphiteGlobResult(unittest.TestCase):
 
     def test_GlobMetricResult_built_from_a_metric_should_discover_its_name(self):
         metric_name = "foo.bar"
-        metric = bg_metric.Metric(name=metric_name, id="0", metadata=bg_metric.MetricMetadata())
+        metric = bg_metric.Metric(
+            name=metric_name, id="0", metadata=bg_metric.MetricMetadata.create())
 
         metric_result = bg_glob.GlobMetricResult.from_value(metric)
 

--- a/tests/test_metadata_cache.py
+++ b/tests/test_metadata_cache.py
@@ -200,7 +200,7 @@ class TestNoneCache(unittest.TestCase):
     TEST_METRIC_NAME = "foo.bar"
     TEST_METRIC = bg_metric.make_metric(
         TEST_METRIC_NAME,
-        bg_metric.MetricMetadata()
+        bg_metric.MetricMetadata.create()
     )
 
     def setUp(self):

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
+import gc
+import prometheus_client
+import weakref
 
 from biggraphite import metric as bg_metric
 from tests import test_utils as bg_test_utils
@@ -46,3 +49,102 @@ class TestAccessorFunctions(unittest.TestCase):
         self.assertEqual("", bg_metric.sanitize_metric_name(""))
         self.assertEqual("", bg_metric.sanitize_metric_name("."))
         self.assertEqual("", bg_metric.sanitize_metric_name(".."))
+
+
+class TestMetricMetadata(unittest.TestCase):
+    DEFAULT_AGGREGATOR = bg_metric.Aggregator.average
+
+    DEFAULT_RETENTION = bg_metric.Retention.from_string("86400*1s:10080*60s")
+    TEST_RETENTION = bg_metric.Retention.from_string("42*10s")
+
+    DEFAULT_XFACTOR = 0.5
+
+    def test_create_should_define_default_values_when_no_parameters_given(self):
+        """Ensure default parameters."""
+        metadata = bg_metric.MetricMetadata.create()
+        self.assertEqual(metadata.aggregator, self.DEFAULT_AGGREGATOR)
+        self.assertEqual(metadata.retention, self.DEFAULT_RETENTION)
+        self.assertEqual(metadata.carbon_xfilesfactor, self.DEFAULT_XFACTOR)
+
+    def test_metadata_object_should_be_the_same_when_created_with_same_parameters(self):
+        """MetricMetadata.create() should always return the same MetricMetadata instance."""
+        metadata1 = bg_metric.MetricMetadata.create(self.DEFAULT_AGGREGATOR,
+                                                    self.DEFAULT_RETENTION,
+                                                    self.DEFAULT_XFACTOR)
+        metadata2 = bg_metric.MetricMetadata.create(self.DEFAULT_AGGREGATOR,
+                                                    self.DEFAULT_RETENTION,
+                                                    self.DEFAULT_XFACTOR)
+        self.assertIs(metadata1, metadata2)
+
+        # the returned instance should't depend on the order of the parameters
+        metadata3 = bg_metric.MetricMetadata.create(carbon_xfilesfactor=self.DEFAULT_XFACTOR,
+                                                    aggregator=self.DEFAULT_AGGREGATOR,
+                                                    retention=self.DEFAULT_RETENTION)
+        self.assertIs(metadata1, metadata3)
+
+    def test_xfilesfactor_should_have_no_impact_on_uniqueness(self):
+        """Check that carbon_xfilesfactor has no influence on uniqueness."""
+        metadata1 = bg_metric.MetricMetadata.create(self.DEFAULT_AGGREGATOR,
+                                                    self.DEFAULT_RETENTION,
+                                                    self.DEFAULT_XFACTOR)
+        metadata2 = bg_metric.MetricMetadata.create(self.DEFAULT_AGGREGATOR,
+                                                    self.DEFAULT_RETENTION,
+                                                    self.DEFAULT_XFACTOR - 0.1)
+
+        self.assertIsNot(metadata1, metadata2)
+
+    def test_aggregator_should_have_no_impact_on_uniqueness(self):
+        """Check that aggregator has no influence on uniqueness."""
+        metadata1 = bg_metric.MetricMetadata.create(self.DEFAULT_AGGREGATOR,
+                                                    self.DEFAULT_RETENTION,
+                                                    self.DEFAULT_XFACTOR)
+        metadata2 = bg_metric.MetricMetadata.create(bg_metric.Aggregator.total,
+                                                    self.DEFAULT_RETENTION,
+                                                    self.DEFAULT_XFACTOR)
+
+        self.assertIsNot(metadata1, metadata2)
+
+    def test_retention_should_have_no_impact_on_uniqueness(self):
+        """Check that retention has no influence on uniqueness."""
+        metadata1 = bg_metric.MetricMetadata.create(self.DEFAULT_AGGREGATOR,
+                                                    self.DEFAULT_RETENTION,
+                                                    self.DEFAULT_XFACTOR)
+        metadata2 = bg_metric.MetricMetadata.create(self.DEFAULT_AGGREGATOR,
+                                                    self.TEST_RETENTION,
+                                                    self.DEFAULT_XFACTOR)
+
+        self.assertIsNot(metadata1, metadata2)
+
+    def test_metadata_object_should_be_deleted_when_there_is_no_more_references_on_it(self):
+        """Check that a metadata are properly cleaned-up when no one holds a reference on it."""
+        metadata = bg_metric.MetricMetadata.create(self.DEFAULT_AGGREGATOR,
+                                                   self.TEST_RETENTION,
+                                                   self.DEFAULT_XFACTOR)
+
+        metadata_weak = weakref.ref(metadata)
+        self.assertIsNotNone(metadata_weak())
+
+        # remove reference and force garbage collection
+        del metadata
+        gc.collect()
+        self.assertIsNone(metadata_weak())
+
+    def test_total_metadata_object_count_should_be_reported_by_prometheus_client(self):
+        """Test the gauge reporting the number of metadata hold in the internal dictionnary."""
+        def get_metadata_instances_count():
+            return prometheus_client.REGISTRY.get_sample_value('bg_metadata_instances_count')
+
+        # make sure previously allocated metadata are cleaned up before starting the test
+        gc.collect()
+
+        # allocate a new metadata object
+        metadata_count_before = get_metadata_instances_count()
+        metadata = bg_metric.MetricMetadata.create(self.DEFAULT_AGGREGATOR,
+                                                   self.TEST_RETENTION,
+                                                   self.DEFAULT_XFACTOR)
+        self.assertEqual(get_metadata_instances_count() - metadata_count_before, 1)
+
+        # delete the reference on the metadata object
+        del metadata
+        gc.collect()
+        self.assertEqual(get_metadata_instances_count(), metadata_count_before)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -109,7 +109,7 @@ def make_metric(name, metadata=None, **kwargs):
         assert isinstance(metadata, bg_metric.MetricMetadata)
         assert not kwargs
     else:
-        metadata = bg_metric.MetricMetadata(**kwargs)
+        metadata = bg_metric.MetricMetadata.create(**kwargs)
     return bg_metric.make_metric(name, metadata)
 
 


### PR DESCRIPTION
Today for every Metric object, we create a MetricMetadata object. This is a waste of memory since the same metadata can be shared by several metrics.

This change aims to rationalize the number of MetricMetadata objects created in biggraphite. I replaced all the calls to MetricMetadata's constructor by a call to MetricMetadata.create() who will create a MetricMetadata if necessary or return an existing one.

What do you think?

TODO:
- I know there is a problem with the xfilesfactor that is used as a dictionary key. It could be a problem because of the float representation.
- Add documentation/comments
- cleanup asserts in MetricMetadata.create()