### PR TITLE
Adapt biggraphite to use the lastest version of prometheus client and bump to 0.13.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - —
 
+## [0.13.12] - 2018-12-13
+
+### Fixed
+- adapt biggraphite to use the new prometheus client API
+
 ## [0.13.11] - 2018-12-12
 
 ### Fixed
@@ -322,7 +327,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - We are going to do releases from now on
 
-[Unreleased]: https://github.com/criteo/biggraphite/compare/v0.13.11...HEAD
+[Unreleased]: https://github.com/criteo/biggraphite/compare/v0.13.12...HEAD
+[0.13.11]: https://github.com/criteo/biggraphite/compare/v0.13.11...v0.13.12
 [0.13.11]: https://github.com/criteo/biggraphite/compare/v0.13.10...v0.13.11
 [0.13.10]: https://github.com/criteo/biggraphite/compare/v0.13.9...v0.13.10
 [0.13.9]: https://github.com/criteo/biggraphite/compare/v0.13.8...v0.13.9

--- a/biggraphite/plugins/carbon.py
+++ b/biggraphite/plugins/carbon.py
@@ -250,16 +250,16 @@ class BigGraphiteDatabase(database.TimeSeriesDatabase):
 
         log.cache("background operations")
         for metric in prometheus_client.REGISTRY.collect():
-            for name, labels, value in metric.samples:
-                name = name
-                if labels:
+            for sample in metric.samples:
+                name = sample.name
+                if sample.labels:
                     name += "." + ".".join(
                         [
                             "%s.%s" % (k, v.replace(".", "_"))
-                            for k, v in sorted(labels.items())
+                            for k, v in sorted(sample.labels.items())
                         ]
                     )
-                instrumentation.cache_record(name, value)
+                instrumentation.cache_record(name, sample.value)
         if self._accessor:
             self.reactor.callInThread(self.accessor.background)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ certifi
 # Core
 six
 cachetools
-prometheus_client
+prometheus_client==0.5.0
 
 # Metadata cache
 lmdb

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ packages = setuptools.find_packages()
 
 setuptools.setup(
     name="biggraphite",
-    version="0.13.11",
+    version="0.13.12",
     maintainer="Criteo Graphite Team",
     maintainer_email="github@criteo.com",
     description="Simple Scalable Time Series Database.",


### PR DESCRIPTION
The Prometheus client changed the metric API from version 0.4.0.

This change makes it compatible to the newer API and freeze prometheus_client to version 0.5.0.