### PR TITLE
Adapt biggraphite to use the lastest version of prometheus client and bump to 0.14.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.14.5] - 2018-12-13
+
+### Fixed
+
+- adapt biggraphite to use the lastest version of prometheus client
+
 ## [0.14.4] - 2018-12-13
 
 ### Fixed
@@ -435,7 +441,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - We are going to do releases from now on
 
-[Unreleased]: https://github.com/criteo/biggraphite/compare/v0.14.4...HEAD
+[Unreleased]: https://github.com/criteo/biggraphite/compare/v0.14.5...HEAD
+[0.14.4]: https://github.com/criteo/biggraphite/compare/v0.14.4...v0.14.5
 [0.14.4]: https://github.com/criteo/biggraphite/compare/v0.14.3...v0.14.4
 [0.14.3]: https://github.com/criteo/biggraphite/compare/v0.14.2...0.14.3
 [0.14.2]: https://github.com/criteo/biggraphite/compare/v0.14.1...v0.14.2

--- a/biggraphite/plugins/carbon.py
+++ b/biggraphite/plugins/carbon.py
@@ -260,16 +260,16 @@ class BigGraphiteDatabase(database.TimeSeriesDatabase):
 
         log.cache("background operations")
         for metric in prometheus_client.REGISTRY.collect():
-            for name, labels, value in metric.samples:
-                name = name
-                if labels:
+            for sample in metric.samples:
+                name = sample.name
+                if sample.labels:
                     name += "." + ".".join(
                         [
                             "%s.%s" % (k, v.replace(".", "_"))
-                            for k, v in sorted(labels.items())
+                            for k, v in sorted(sample.labels.items())
                         ]
                     )
-                instrumentation.cache_record(name, value)
+                instrumentation.cache_record(name, sample.value)
         if self._accessor:
             self.reactor.callInThread(self.accessor.background)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ ciso8601
 # Core
 six
 cachetools
-prometheus_client
+prometheus_client==0.5.0
 
 # Metadata cache
 lmdb

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ packages = setuptools.find_packages()
 
 setuptools.setup(
     name="biggraphite",
-    version="0.14.4",
+    version="0.14.5",
     maintainer="Criteo Graphite Team",
     maintainer_email="github@criteo.com",
     description="Simple Scalable Time Series Database.",


### PR DESCRIPTION
The Prometheus client changed the metric API from version 0.4.0.

This change makes it compatible to the newer API and freeze prometheus_client to version 0.5.0.