### PR TITLE
fix accessor cache on python 3.x

### DIFF
--- a/biggraphite/accessor_cache.py
+++ b/biggraphite/accessor_cache.py
@@ -17,6 +17,8 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import sys
+
 import abc
 import hashlib
 
@@ -93,6 +95,8 @@ class DjangoCache(AccessorCache):
 
     def _make_key(self, key):
         """Construct a clean key from a key."""
+        if sys.version_info > (3, 0):
+            key = key.encode('utf-8')
         return hashlib.md5(key).hexdigest()
 
     def set(self, key, value, timeout=None, version=None):


### PR DESCRIPTION
This is the only issue I've found so far running on Python 3.6 instead of Python 2.7 (an upgrade I'm trying to do now since Python 2.7 EOLs this year). Applying this patch results in correct rendering in graphite and correct ingestion through bg-carbon-cache.