### PR TITLE
Wait metadata to be read before touching them

### DIFF
--- a/biggraphite/cli/command_copy.py
+++ b/biggraphite/cli/command_copy.py
@@ -144,7 +144,7 @@ class CommandCopy(command.BaseCommand):
                 )
                 dst_metadata = bg_metric.MetricMetadata.create(
                         src_metadata.aggregator, dst_retention, src_metadata.carbon_xfilesfactor)
-                dst_metric = bg_metric.make_metric(dst_metric_name, dst_metadata)
+                dst_metric = bg_metric.make_metric_with_defaults(dst_metric_name, dst_metadata)
                 if not dry_run:
                     accessor.create_metric(dst_metric)
             elif dst_retention and dst_metric.metadata.retention != dst_retention:

--- a/biggraphite/cli/command_write.py
+++ b/biggraphite/cli/command_write.py
@@ -81,7 +81,7 @@ class CommandWrite(command.BaseCommand):
                 retention=bg_metric.Retention.from_string(opts.retention),
                 carbon_xfilesfactor=opts.x_files_factor,
             )
-            metric = bg_metric.make_metric(opts.metric, metadata)
+            metric = bg_metric.make_metric_with_defaults(opts.metric, metadata)
             accessor.create_metric(metric)
 
         timestamp = int(time.mktime(opts.timestamp.timetuple()))

--- a/biggraphite/cli/import_whisper.py
+++ b/biggraphite/cli/import_whisper.py
@@ -140,7 +140,7 @@ class _Worker(object):
         if not metadata:
             return 0
 
-        metric = bg_metric.make_metric(name, metadata)
+        metric = bg_metric.make_metric_with_defaults(name, metadata)
         if not self._opts.no_metadata:
             self._accessor.create_metric(metric)
 

--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -2085,7 +2085,9 @@ class _CassandraAccessor(bg_accessor.Accessor):
             return
 
         if not metric.updated_on:
-            delta = self.__metadata_touch_ttl_sec + 1
+            # updated_on is not set, it means the metric has
+            # not been read yet from cassandra and we do nothing
+            return
         else:
             delta = int(time.time()) - int(time.mktime(metric.updated_on.timetuple()))
 

--- a/biggraphite/drivers/elasticsearch.py
+++ b/biggraphite/drivers/elasticsearch.py
@@ -511,7 +511,7 @@ class _ElasticSearchAccessor(bg_accessor.Accessor):
         if metric is None:
             raise InvalidArgumentError("Unknown metric '%s'" % name)
 
-        updated_metric = bg_metric.make_metric(
+        updated_metric = bg_metric.make_metric_with_defaults(
             name,
             updated_metadata,
             created_on=metric.created_on,
@@ -700,7 +700,7 @@ class _ElasticSearchAccessor(bg_accessor.Accessor):
         metadata = bg_metric.MetricMetadata.from_string_dict(document.config.to_dict())
         # TODO: Have a look at dsl doc to avoid parsing strings to dates
         # https://github.com/elastic/elasticsearch-dsl-py/blob/master/docs/persistence.rst
-        return bg_metric.make_metric(
+        return bg_metric.make_metric_with_defaults(
             document.name,
             metadata,
             created_on=ttls.str_to_datetime(document.created_on),

--- a/biggraphite/metric.py
+++ b/biggraphite/metric.py
@@ -130,8 +130,32 @@ def encode_metric_name(name):
     return _UTF8_CODEC(name)[0]
 
 
-def make_metric(name, metadata, created_on=None, updated_on=None, read_on=None):
-    """Create a Metric object from its definition as name and metadata.
+def make_metric_with_defaults(
+    name, metadata, created_on=None, updated_on=None, read_on=None
+):
+    """Helper to create a Metric object from its definition as name and metadata.
+
+    Args:
+      name: metric name.
+      metadata: metric metadata.
+      created_on: metric creation date, current date if None
+      updated_on: metric last update date, current date if None
+      read_on: metric last read date, defaults to None
+
+    Returns: a Metric object with a valid id.
+    """
+    now = datetime.datetime.now()
+    return make_metric(
+        name,
+        metadata,
+        created_on=created_on or now,
+        updated_on=updated_on or now,
+        read_on=read_on,
+    )
+
+
+def make_metric(name, metadata, created_on, updated_on, read_on):
+    """Create a Metric object.
 
     Args:
       name: metric name.
@@ -142,17 +166,14 @@ def make_metric(name, metadata, created_on=None, updated_on=None, read_on=None):
 
     Returns: a Metric object with a valid id.
     """
-    encoded_name = encode_metric_name(
-        sanitize_metric_name(name)
-    )
+    encoded_name = encode_metric_name(sanitize_metric_name(name))
     uid = uuid.uuid5(_UUID_NAMESPACE, encoded_name)
-    now = datetime.datetime.now()
     return Metric(
         encoded_name,
         uid,
         metadata,
-        created_on=created_on or now,
-        updated_on=updated_on or now,
+        created_on=created_on,
+        updated_on=updated_on,
         read_on=read_on,
     )
 
@@ -662,10 +683,13 @@ class MetricMetadata(object):
         # since the value this used as a dictionnary key.
         carbon_xfilesfactor_normalized = None
         if carbon_xfilesfactor:
-            carbon_xfilesfactor_normalized = round(carbon_xfilesfactor, cls._XFILESFACTOR_PRECISION)
+            carbon_xfilesfactor_normalized = round(
+                carbon_xfilesfactor, cls._XFILESFACTOR_PRECISION
+            )
         metadata = cls.__metadata_instances.setdefault(
-                                    (aggregator, retention, carbon_xfilesfactor_normalized),
-                                    cls(aggregator, retention, carbon_xfilesfactor_normalized))
+            (aggregator, retention, carbon_xfilesfactor_normalized),
+            cls(aggregator, retention, carbon_xfilesfactor_normalized),
+        )
 
         return metadata
 

--- a/tests/cli/test_bgutil.py
+++ b/tests/cli/test_bgutil.py
@@ -31,7 +31,7 @@ class TestBgutil(bg_test_utils.TestCaseWithFakeAccessor):
     def test_run(self, mock_stdout):
         self.accessor.drop_all_metrics()
         for metric in self.metrics:
-            self.accessor.create_metric(bg_test_utils.make_metric(metric))
+            self.accessor.create_metric(bg_test_utils.make_metric_with_defaults(metric))
         bgutil.main(["--driver=memory", "read", "**"], self.accessor)
         output = mock_stdout.getvalue()
         for metric in self.metrics:

--- a/tests/cli/test_command_copy.py
+++ b/tests/cli/test_command_copy.py
@@ -31,11 +31,11 @@ class TestCommandCopy(bg_test_utils.TestCaseWithFakeAccessor):
         start=_POINTS_START, end=_POINTS_END, period=_RETENTION[1].precision
     )
     _METRIC_1_NAME = "test.origin.metric_1.toto"
-    _METRIC_1 = bg_test_utils.make_metric(_METRIC_1_NAME, retention=_RETENTION)
+    _METRIC_1 = bg_test_utils.make_metric_with_defaults(_METRIC_1_NAME, retention=_RETENTION)
     _METRIC_2_NAME = "test.origin.metric_2.tata"
-    _METRIC_2 = bg_test_utils.make_metric(_METRIC_2_NAME, retention=_RETENTION)
+    _METRIC_2 = bg_test_utils.make_metric_with_defaults(_METRIC_2_NAME, retention=_RETENTION)
     _METRIC_3_NAME = "test.origin.metric_3.tata"
-    _METRIC_3 = bg_test_utils.make_metric(_METRIC_3_NAME, retention=_RETENTION_BIS)
+    _METRIC_3 = bg_test_utils.make_metric_with_defaults(_METRIC_3_NAME, retention=_RETENTION_BIS)
 
     def setUp(self):
         """Set up a subdirectory of metrics to copy."""

--- a/tests/cli/test_command_delete.py
+++ b/tests/cli/test_command_delete.py
@@ -38,7 +38,7 @@ class TestCommandDelete(bg_test_utils.TestCaseWithFakeAccessor):
             retention=bg_metric.Retention.from_string("1440*60s")
         )
 
-        self.accessor.create_metric(bg_test_utils.make_metric(name, metadata))
+        self.accessor.create_metric(bg_test_utils.make_metric_with_defaults(name, metadata))
         opts = parser.parse_args(["foo", "--recursive", "--dry-run"])
         cmd.run(self.accessor, opts)
         self.assertIn(name, self.accessor.glob_metric_names("*.*"))

--- a/tests/cli/test_command_du.py
+++ b/tests/cli/test_command_du.py
@@ -37,7 +37,7 @@ class TestCommandDu(bg_test_utils.TestCaseWithFakeAccessor):
         self.accessor.drop_all_metrics()
         for metric in self.metrics:
             self.accessor.create_metric(
-                bg_test_utils.make_metric(metric, self.metadata)
+                bg_test_utils.make_metric_with_defaults(metric, self.metadata)
             )
 
         cmd = command_du.CommandDu()

--- a/tests/cli/test_command_graphite_web.py
+++ b/tests/cli/test_command_graphite_web.py
@@ -29,7 +29,7 @@ class TestCommandGraphiteWeb(bg_test_utils.TestCaseWithFakeAccessor):
         metadata = bg_metric.MetricMetadata.create(
             retention=bg_metric.Retention.from_string("1440*60s")
         )
-        self.accessor.create_metric(bg_test_utils.make_metric(name, metadata))
+        self.accessor.create_metric(bg_test_utils.make_metric_with_defaults(name, metadata))
         self.accessor.flush()
 
         cmd = command_graphite_web.CommandGraphiteWeb()

--- a/tests/cli/test_command_list.py
+++ b/tests/cli/test_command_list.py
@@ -38,7 +38,7 @@ class TestCommandList(bg_test_utils.TestCaseWithFakeAccessor):
             retention=bg_metric.Retention.from_string("1440*60s")
         )
 
-        self.accessor.create_metric(bg_test_utils.make_metric(name, metadata))
+        self.accessor.create_metric(bg_test_utils.make_metric_with_defaults(name, metadata))
 
         opts = parser.parse_args(["foo.*"])
         cmd.run(self.accessor, opts)

--- a/tests/cli/test_command_read.py
+++ b/tests/cli/test_command_read.py
@@ -29,7 +29,7 @@ class TestCommandRead(bg_test_utils.TestCaseWithFakeAccessor):
         metadata = bg_metric.MetricMetadata.create(
             retention=bg_metric.Retention.from_string("1440*60s")
         )
-        self.accessor.create_metric(bg_test_utils.make_metric(name, metadata))
+        self.accessor.create_metric(bg_test_utils.make_metric_with_defaults(name, metadata))
 
         cmd = command_read.CommandRead()
 

--- a/tests/cli/test_command_stats.py
+++ b/tests/cli/test_command_stats.py
@@ -37,7 +37,7 @@ class TestCommandStats(bg_test_utils.TestCaseWithFakeAccessor):
         self.accessor.drop_all_metrics()
         for metric in self.metrics:
             self.accessor.create_metric(
-                bg_test_utils.make_metric(metric, self.metadata)
+                bg_test_utils.make_metric_with_defaults(metric, self.metadata)
             )
 
         cmd = command_stats.CommandStats()

--- a/tests/drivers/base_test_metadata.py
+++ b/tests/drivers/base_test_metadata.py
@@ -61,7 +61,7 @@ class BaseTestAccessorMetadata(object):
         metrics.sort()
 
         for name in metrics:
-            metric = bg_test_utils.make_metric(name)
+            metric = bg_test_utils.make_metric_with_defaults(name)
             self.accessor.create_metric(metric)
         self.flush()
 
@@ -163,7 +163,7 @@ class BaseTestAccessorMetadata(object):
     def test_glob_directories(self):
         IS_ELASTICSEARCH = self.ACCESSOR_SETTINGS.get("driver", "") == "elasticsearch"
         for name in "a", "a.b", "x.y.z":
-            metric = bg_test_utils.make_metric(name)
+            metric = bg_test_utils.make_metric_with_defaults(name)
             self.accessor.create_metric(metric)
         self.flush()
 
@@ -196,7 +196,7 @@ class BaseTestAccessorMetadata(object):
 
         metrics = ["a", "a.b", "x.y.z"]
         for name in metrics:
-            metric = bg_test_utils.make_metric(name)
+            metric = bg_test_utils.make_metric_with_defaults(name)
             self.accessor.create_metric(metric)
         self.flush()
 
@@ -232,7 +232,7 @@ class BaseTestAccessorMetadata(object):
             "retention": bg_metric.Retention.from_string("60*1s:60*60s"),
             "carbon_xfilesfactor": 0.3,
         }
-        metric = bg_test_utils.make_metric("a.b.c.d.e.f", **meta_dict)
+        metric = bg_test_utils.make_metric_with_defaults("a.b.c.d.e.f", **meta_dict)
 
         self.assertEqual(self.accessor.has_metric(metric.name), False)
         self.accessor.create_metric(metric)
@@ -258,7 +258,7 @@ class BaseTestAccessorMetadata(object):
         }
         metadata = bg_metric.MetricMetadata.create(**meta_dict)
         metric_name = "a.b.c.d.e.f"
-        self.accessor.create_metric(bg_test_utils.make_metric(metric_name, metadata))
+        self.accessor.create_metric(bg_test_utils.make_metric_with_defaults(metric_name, metadata))
         self.flush()
         metric = self.accessor.get_metric(metric_name)
         for k, v in meta_dict.items():
@@ -285,7 +285,7 @@ class BaseTestAccessorMetadata(object):
         )
 
     def test_has_metric(self):
-        metric = bg_test_utils.make_metric("a.b.c.d.e.f")
+        metric = bg_test_utils.make_metric_with_defaults("a.b.c.d.e.f")
 
         self.assertEqual(self.accessor.has_metric(metric.name), False)
         self.accessor.create_metric(metric)
@@ -299,7 +299,7 @@ class BaseTestAccessorMetadata(object):
                 "delete_metric is not implemented for _ElasticSearchAccessor."
             )
 
-        metric = bg_test_utils.make_metric("a.b.c.d.e.f")
+        metric = bg_test_utils.make_metric_with_defaults("a.b.c.d.e.f")
 
         self.accessor.create_metric(metric)
         self.flush()
@@ -318,8 +318,8 @@ class BaseTestAccessorMetadata(object):
         self.accessor.repair()
 
     def test_get_metric_doubledots(self):
-        metric = bg_test_utils.make_metric("a.b..c")
-        metric_1 = bg_test_utils.make_metric("a.b.c")
+        metric = bg_test_utils.make_metric_with_defaults("a.b..c")
+        metric_1 = bg_test_utils.make_metric_with_defaults("a.b.c")
         self.accessor.create_metric(metric)
         self.accessor.create_metric(metric_1)
         self.flush()
@@ -333,10 +333,10 @@ class BaseTestAccessorMetadata(object):
             # TODO (t.chataigner) Remove once clean is implemented.
             self.skipTest("clean is not implemented for _ElasticSearchAccessor.")
 
-        metric1 = bg_test_utils.make_metric("a.b.c.d.e.f")
+        metric1 = bg_test_utils.make_metric_with_defaults("a.b.c.d.e.f")
         self.accessor.create_metric(metric1)
 
-        metric2 = bg_test_utils.make_metric("g.h.i.j.k.l")
+        metric2 = bg_test_utils.make_metric_with_defaults("g.h.i.j.k.l")
         self.accessor.create_metric(metric2)
         self.flush()
 
@@ -358,10 +358,10 @@ class BaseTestAccessorMetadata(object):
             # TODO (t.chataigner) Remove once clean is implemented.
             self.skipTest("clean is not implemented for _ElasticSearchAccessor.")
 
-        metric1 = bg_test_utils.make_metric("a.b.c.d.e.f")
+        metric1 = bg_test_utils.make_metric_with_defaults("a.b.c.d.e.f")
         self.accessor.create_metric(metric1)
 
-        metric2 = bg_test_utils.make_metric("g.h.i.j.k.l")
+        metric2 = bg_test_utils.make_metric_with_defaults("g.h.i.j.k.l")
         self.accessor.create_metric(metric2)
         self.flush()
 
@@ -379,10 +379,10 @@ class BaseTestAccessorMetadata(object):
         self.addCleanup(self.accessor.drop_all_metrics)
 
     def test_map(self):
-        metric1 = bg_test_utils.make_metric("a.b.c.d.e.f")
+        metric1 = bg_test_utils.make_metric_with_defaults("a.b.c.d.e.f")
         self.accessor.create_metric(metric1)
 
-        metric2 = bg_test_utils.make_metric("g.h.i.j.k.l")
+        metric2 = bg_test_utils.make_metric_with_defaults("g.h.i.j.k.l")
         self.accessor.create_metric(metric2)
         self.flush()
 
@@ -396,7 +396,7 @@ class BaseTestAccessorMetadata(object):
         self.accessor.map(_callback, errback=_errback)
 
     def test_touch_without_create(self):
-        metric = bg_test_utils.make_metric("foo")
+        metric = bg_test_utils.make_metric_with_defaults("foo")
         self.accessor.touch_metric(metric)
         self.accessor.create_metric(metric)
         self.accessor.touch_metric(metric)

--- a/tests/drivers/test_cassandra.py
+++ b/tests/drivers/test_cassandra.py
@@ -25,7 +25,7 @@ from tests import test_utils as bg_test_utils
 from tests.drivers.base_test_metadata import BaseTestAccessorMetadata
 from tests.test_utils_cassandra import HAS_CASSANDRA
 
-_METRIC = bg_test_utils.make_metric("test.metric")
+_METRIC = bg_test_utils.make_metric_with_defaults("test.metric")
 
 # Points test query.
 _QUERY_RANGE = 3600
@@ -47,7 +47,7 @@ class TestAccessorWithCassandraSASI(
 ):
     def test_glob_too_many_directories(self):
         for name in "a", "a.b", "x.y.z":
-            metric = bg_test_utils.make_metric(name)
+            metric = bg_test_utils.make_metric_with_defaults(name)
             self.accessor.create_metric(metric)
         self.flush()
 
@@ -59,7 +59,7 @@ class TestAccessorWithCassandraSASI(
 
     # FIXME (t.chataigner) some duplication with ElasticsearchTestAccessorMetadata.
     def test_metric_is_updated_after_ttl(self):
-        metric = bg_test_utils.make_metric("foo")
+        metric = bg_test_utils.make_metric_with_defaults("foo")
         self.accessor.create_metric(metric)
         self.flush()
 
@@ -101,7 +101,7 @@ class TestAccessorWithCassandraData(bg_test_utils.TestCaseWithAccessor):
         return list(ret)
 
     def test_fetch_empty(self):
-        no_such_metric = bg_test_utils.make_metric("no.such.metric")
+        no_such_metric = bg_test_utils.make_metric_with_defaults("no.such.metric")
         self.accessor.insert_points(_METRIC, _POINTS)
         self.flush()
         self.accessor.drop_all_metrics()
@@ -161,8 +161,8 @@ class TestAccessorWithCassandraData(bg_test_utils.TestCaseWithAccessor):
         self.assertEqual(_USEFUL_POINTS, fetched)
 
     def test_fetch_doubledots(self):
-        metric = bg_test_utils.make_metric("a.b..c")
-        metric_1 = bg_test_utils.make_metric("a.b.c")
+        metric = bg_test_utils.make_metric_with_defaults("a.b..c")
+        metric_1 = bg_test_utils.make_metric_with_defaults("a.b.c")
         points = [(1, 42)]
         self.accessor.create_metric(metric)
         self.accessor.create_metric(metric_1)

--- a/tests/drivers/test_drivers_delayed_writer.py
+++ b/tests/drivers/test_drivers_delayed_writer.py
@@ -43,7 +43,7 @@ class TestDelayedWriter(test_utils.TestCaseWithFakeAccessor):
         metadata = bg_metric.MetricMetadata.create(
             aggregator=bg_metric.Aggregator.average, retention=retention
         )
-        self.metric = test_utils.make_metric(self.METRIC_NAME, metadata=metadata)
+        self.metric = test_utils.make_metric_with_defaults(self.METRIC_NAME, metadata=metadata)
         self.accessor.create_metric(self.metric)
         self.dw = bg_dw.DelayedWriter(self.accessor, period_ms=self.WRITER_PERIOD)
 

--- a/tests/drivers/test_memory.py
+++ b/tests/drivers/test_memory.py
@@ -23,7 +23,7 @@ class TestInMemoryAccessor(bg_test_utils.TestCaseWithAccessor):
 
     def test_glob_metric_names_should_return_names_matching_glob(self):
         metric_name = "test_glob_metric_names_should_return_names_matching_glob.a.b.c"
-        metric = bg_test_utils.make_metric(metric_name, _create_default_metadata())
+        metric = bg_test_utils.make_metric_with_defaults(metric_name, _create_default_metadata())
         self.accessor.create_metric(metric)
         self.accessor.flush()
 
@@ -35,7 +35,7 @@ class TestInMemoryAccessor(bg_test_utils.TestCaseWithAccessor):
 
     def test_glob_metric_names_should_not_return_names_not_matching_glob(self):
         metric_name = "test_glob_metric_names_should_not_return_names_not_matching_glob.a.b.c"
-        metric = bg_test_utils.make_metric(metric_name, _create_default_metadata())
+        metric = bg_test_utils.make_metric_with_defaults(metric_name, _create_default_metadata())
         self.accessor.create_metric(metric)
         self.accessor.flush()
 
@@ -45,7 +45,7 @@ class TestInMemoryAccessor(bg_test_utils.TestCaseWithAccessor):
 
     def test_glob_metrics_should_return_metrics_matching_glob(self):
         metric_name = "test_glob_metrics_should_return_metrics_matching_glob.a.b.c"
-        metric = bg_test_utils.make_metric(metric_name, _create_default_metadata())
+        metric = bg_test_utils.make_metric_with_defaults(metric_name, _create_default_metadata())
         self.accessor.create_metric(metric)
         self.accessor.flush()
 
@@ -57,7 +57,7 @@ class TestInMemoryAccessor(bg_test_utils.TestCaseWithAccessor):
 
     def test_glob_metrics_should_not_return_metrics_not_matching_glob(self):
         metric_name = "test_glob_metrics_should_not_return_metrics_not_matching_glob.a.b.c"
-        metric = bg_test_utils.make_metric(metric_name, _create_default_metadata())
+        metric = bg_test_utils.make_metric_with_defaults(metric_name, _create_default_metadata())
         self.accessor.create_metric(metric)
         self.accessor.flush()
 

--- a/tests/plugins/test_carbon.py
+++ b/tests/plugins/test_carbon.py
@@ -101,7 +101,7 @@ class TestCarbonDatabase(bg_test_utils.TestCaseWithFakeAccessor):
 
     def test_create_async(self):
         metric_name = "a.b.c"
-        metric = bg_test_utils.make_metric(metric_name)
+        metric = bg_test_utils.make_metric_with_defaults(metric_name)
 
         self._plugin._createAsyncOrig(metric, metric_name)
         self.assertFalse(self._plugin.exists(metric_name))
@@ -109,7 +109,7 @@ class TestCarbonDatabase(bg_test_utils.TestCaseWithFakeAccessor):
         self.assertTrue(self._plugin.exists(metric_name))
 
         # See if we can update.
-        metric = bg_test_utils.make_metric(
+        metric = bg_test_utils.make_metric_with_defaults(
             metric_name, retention=bg_metric.Retention([bg_metric.Stage(1, 1)])
         )
         self._plugin._createAsyncOrig(metric, metric_name)
@@ -190,8 +190,8 @@ class TestCarbonDatabase(bg_test_utils.TestCaseWithFakeAccessor):
         self.assertEqual(points, list(actual_points))
 
     def test_write_doubledots(self):
-        metric = bg_test_utils.make_metric("a.b..c")
-        metric_1 = bg_test_utils.make_metric("a.b.c")
+        metric = bg_test_utils.make_metric_with_defaults("a.b..c")
+        metric_1 = bg_test_utils.make_metric_with_defaults("a.b.c")
         points = [(1, 42)]
         self.accessor.create_metric(metric)
         self._plugin.write(metric.name, points)

--- a/tests/plugins/test_graphite.py
+++ b/tests/plugins/test_graphite.py
@@ -40,7 +40,9 @@ class TestReader(bg_test_utils.TestCaseWithFakeAccessor):
     _POINTS = bg_test_utils._make_easily_queryable_points(
         start=_POINTS_START, end=_POINTS_END, period=_RETENTION[1].precision
     )
-    _METRIC = bg_test_utils.make_metric(_METRIC_NAME, retention=_RETENTION)
+    _METRIC = bg_test_utils.make_metric_with_defaults(
+        _METRIC_NAME, retention=_RETENTION
+    )
 
     def setUp(self):
         super(TestReader, self).setUp()
@@ -98,7 +100,9 @@ class TestReader(bg_test_utils.TestCaseWithFakeAccessor):
     def test_carbon_protocol_read(self):
         metric_name = "fake.name"
         # Custom aggregator to make sure all goes right.
-        metric = bg_test_utils.make_metric(_METRIC_NAME, aggregator=bg_metric.Aggregator.minimum)
+        metric = bg_test_utils.make_metric_with_defaults(
+            _METRIC_NAME, aggregator=bg_metric.Aggregator.minimum
+        )
         self.accessor.create_metric(metric)
         self.accessor.flush()
         self.reader = bg_graphite.Reader(
@@ -157,7 +161,7 @@ class TestFinder(bg_test_utils.TestCaseWithFakeAccessor):
     def setUp(self):
         super(TestFinder, self).setUp()
         for metric_name in "a", "a.a", "a.b.c", "x.y":
-            metric = bg_test_utils.make_metric(metric_name)
+            metric = bg_test_utils.make_metric_with_defaults(metric_name)
             self.accessor.create_metric(metric)
         self.finder = bg_graphite.Finder(
             accessor=self.accessor, metadata_cache=self.metadata_cache

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -23,7 +23,7 @@ from biggraphite import accessor as bg_accessor
 from biggraphite import metric as bg_metric
 from tests import test_utils as bg_test_utils
 
-_METRIC = bg_test_utils.make_metric("test.metric")
+_METRIC = bg_test_utils.make_metric_with_defaults("test.metric")
 _NAN = float("nan")
 
 
@@ -180,7 +180,7 @@ class TestRetention(unittest.TestCase):
 
 class TestMetricMetadata(unittest.TestCase):
     def test_setattr(self):
-        m = bg_test_utils.make_metric("test")
+        m = bg_test_utils.make_metric_with_defaults("test")
         self.assertTrue(hasattr(m, "carbon_xfilesfactor"))
         self.assertRaises(AttributeError, setattr, m, "carbon_xfilesfactor", 0.5)
 

--- a/tests/test_glob_utils.py
+++ b/tests/test_glob_utils.py
@@ -228,7 +228,7 @@ class TestGlobUtils(bg_test_utils.TestCaseWithFakeAccessor):
 
     def test_graphite_glob(self):
         for name in self._metric_names:
-            metric = bg_test_utils.make_metric(name)
+            metric = bg_test_utils.make_metric_with_defaults(name)
             self.accessor.create_metric(metric)
 
         scenarii = [

--- a/tests/test_metadata_cache.py
+++ b/tests/test_metadata_cache.py
@@ -25,7 +25,7 @@ from biggraphite import metadata_cache as bg_metadata_cache
 from biggraphite import metric as bg_metric
 from tests import test_utils as bg_test_utils
 
-_TEST_METRIC = bg_test_utils.make_metric("a.b.c")
+_TEST_METRIC = bg_test_utils.make_metric_with_defaults("a.b.c")
 
 
 class CacheBaseTest(object):
@@ -70,14 +70,14 @@ class CacheBaseTest(object):
 
     def test_unicode(self):
         metric_name = u"a.b.testé"
-        metric = bg_test_utils.make_metric(metric_name)
+        metric = bg_test_utils.make_metric_with_defaults(metric_name)
         self.metadata_cache.create_metric(metric)
         self.metadata_cache.get_metric(metric_name)
 
     def test_repair(self):
         # Add a normal metric.
         metric_name = "a.b.test"
-        metric = bg_test_utils.make_metric(metric_name)
+        metric = bg_test_utils.make_metric_with_defaults(metric_name)
 
         self.metadata_cache.create_metric(metric)
         self.metadata_cache.repair()
@@ -88,7 +88,7 @@ class CacheBaseTest(object):
 
         # Add a spurious metric.
         metric_name = "a.b.fake"
-        metric = bg_test_utils.make_metric(metric_name)
+        metric = bg_test_utils.make_metric_with_defaults(metric_name)
 
         self.metadata_cache._cache_set(metric_name, metric)
         self.metadata_cache.repair()
@@ -100,7 +100,7 @@ class CacheBaseTest(object):
     def test_repair_shard(self):
         # Add a normal metric.
         metric_name = "a.b.test"
-        metric = bg_test_utils.make_metric(metric_name)
+        metric = bg_test_utils.make_metric_with_defaults(metric_name)
 
         self.metadata_cache.create_metric(metric)
         self.metadata_cache.repair(shard=0, nshards=2)
@@ -112,7 +112,7 @@ class CacheBaseTest(object):
 
         # Add a spurious metric.
         metric_name = "a.b.fake"
-        metric = bg_test_utils.make_metric(metric_name)
+        metric = bg_test_utils.make_metric_with_defaults(metric_name)
 
         self.metadata_cache._cache_set(metric_name, metric)
 
@@ -134,7 +134,7 @@ class CacheBaseTest(object):
         self.assertNotEqual(len(ret), 0)
 
         metric_name = "a.b.test"
-        metric = bg_test_utils.make_metric(metric_name)
+        metric = bg_test_utils.make_metric_with_defaults(metric_name)
 
         self.metadata_cache.create_metric(metric)
 
@@ -178,10 +178,10 @@ class TestDiskCache(CacheBaseTest, bg_test_utils.TestCaseWithFakeAccessor):
     def test_cache_clean(self):
         """Check that the cache is cleared out of metrics older than the TTL."""
         with freeze_time("2014-01-01 00:00:00"):
-            old_metric = bg_test_utils.make_metric("i.am.old")
+            old_metric = bg_test_utils.make_metric_with_defaults("i.am.old")
             self.metadata_cache.create_metric(old_metric)
         with freeze_time("2015-01-01 00:00:00"):
-            new_metric = bg_test_utils.make_metric("i.am.new")
+            new_metric = bg_test_utils.make_metric_with_defaults("i.am.new")
             self.metadata_cache.create_metric(new_metric)
         with freeze_time("2015-01-01 20:00:00"):
             self.metadata_cache.clean()
@@ -198,7 +198,7 @@ class TestMemoryCache(CacheBaseTest, bg_test_utils.TestCaseWithFakeAccessor):
 class TestNoneCache(unittest.TestCase):
 
     TEST_METRIC_NAME = "foo.bar"
-    TEST_METRIC = bg_metric.make_metric(
+    TEST_METRIC = bg_metric.make_metric_with_defaults(
         TEST_METRIC_NAME,
         bg_metric.MetricMetadata.create()
     )

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -23,7 +23,7 @@ from tests import test_utils as bg_test_utils
 
 class TestMetric(unittest.TestCase):
     def test_dir(self):
-        metric = bg_test_utils.make_metric("a.b.c")
+        metric = bg_test_utils.make_metric_with_defaults("a.b.c")
         self.assertIn("name", dir(metric))
         self.assertIn("carbon_xfilesfactor", dir(metric))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -100,7 +100,7 @@ def prepare_graphite_imports():
                 sys.path.insert(0, path)
 
 
-def make_metric(name, metadata=None, **kwargs):
+def make_metric_with_defaults(name, metadata=None, **kwargs):
     """Create a bg_accessor.Metric with specified metadata."""
     retention = kwargs.get("retention")
     if isinstance(retention, str):
@@ -110,7 +110,7 @@ def make_metric(name, metadata=None, **kwargs):
         assert not kwargs
     else:
         metadata = bg_metric.MetricMetadata.create(**kwargs)
-    return bg_metric.make_metric(name, metadata)
+    return bg_metric.make_metric_with_defaults(name, metadata)
 
 
 def _make_easily_queryable_points(start, end, period):


### PR DESCRIPTION
When an aggregator-cache restarts, all the metrics received gets touched and flood Cassandra with updates. It's not an issue when one restarts but it causes problems when many of them restart at the same time.

This fix consist in waiting for the metric creation process to read the metric from Cassandra and to reflect the value of the field "updated_on" in the internal cache. During this time, the metric won't be touched.

This is what happens at restart:
![image](https://user-images.githubusercontent.com/199616/50916543-af688780-143b-11e9-82f0-ae07e8eba08e.png)
