### PR TITLE
Optimized Docker rebuild of graphite containers images

### DIFF
--- a/docker/graphite-aggregator-cache/Dockerfile
+++ b/docker/graphite-aggregator-cache/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.6
+RUN  pip install cassandra-driver
 COPY . /bg/
 WORKDIR /bg
 ENV GRAPHITE_NO_PREFIX=true

--- a/docker/graphite-web/Dockerfile
+++ b/docker/graphite-web/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.6
+RUN  pip install cassandra-driver
 COPY . /bg/
 WORKDIR /bg
 ENV GRAPHITE_NO_PREFIX=true


### PR DESCRIPTION
Added a layer (RUN pip install cassandra-driver) at the beginning af Dockerfile for graphite-aggregator-cache and graphite-web containers.
Since the installation and build of this driver is the one that takes most of the time during the build, that part  of the build will not be processed during subsequent builds triggered by local modification of biggraphite sources.