### PR TITLE
Fixed travis tests

### DIFF
--- a/tests-requirements.txt
+++ b/tests-requirements.txt
@@ -22,7 +22,6 @@ dpkt
 
 # Graphite and dependencies.
 graphite-web
-django-tagging
 pytz
 carbon
 twisted

--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -17,7 +17,7 @@ function install_cassandra()
         cd .deps
         FILENAME="apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz"
         if [ ! -f "${FILENAME}" ]; then
-            wget "http://www.us.apache.org/dist/cassandra/${CASSANDRA_VERSION}/${FILENAME}"
+            wget "http://archive.apache.org/dist/cassandra/${CASSANDRA_VERSION}/${FILENAME}"
             tar -xzf "${FILENAME}"
         fi
         cd -


### PR DESCRIPTION
  - fixed cassandra tarball url in the installation of dependencies
  - removed django-tagging as dependency in test-requirements as this is already a dependency of graphite-web

Signed-off-by: Jean-Francois Weber-Marx <jfwm@hotmail.com>