### PR TITLE
Do not update read_on if the metric is not present

### DIFF
--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -1254,7 +1254,7 @@ class _CassandraAccessor(bg_accessor.Accessor):
             UPDATE_READ_ON_METADATA,
             __prepare(
                 'UPDATE "%s".metrics_metadata SET read_on=now()'
-                " WHERE name=?;" % self.keyspace_metadata
+                " WHERE name=? IF EXISTS;" % self.keyspace_metadata
             )
         )
         self.__delete_metric = _CassandraExecutionRequest(

--- a/tests/drivers/base_test_metadata.py
+++ b/tests/drivers/base_test_metadata.py
@@ -404,3 +404,16 @@ class BaseTestAccessorMetadata(object):
     def test_get_metric_unknown(self):
         unknown_metric_name = 'this.metric.is.unknown'
         self.assertEqual(self.accessor.get_metric(unknown_metric_name), None)
+
+    def test_metric_should_not_be_created_when_updating_read_on(self):
+        metadata = bg_metric.MetricMetadata.create()
+        metric = bg_test_utils.make_metric_with_defaults(
+            'this.metric.should.not.be.created',
+            metadata
+        )
+
+        # fetch_points will update the read_on for the given metric
+        self.accessor.fetch_points(metric, 1, 2, metric.retention.stage0)
+
+        metric_from_db = self.accessor.get_metric(metric.name)
+        self.assertEqual(metric_from_db, None)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -212,6 +212,9 @@ class TestCaseWithAccessor(TestCaseWithTempDir):
                     cls.cassandra_helper.get_accessor_settings()
                 )
 
+        # force read_on to be updated everytime during the tests
+        cls.ACCESSOR_SETTINGS['read_on_sampling_rate'] = 1.0
+
         cls.accessor = bg_accessor_factory.accessor_from_settings(cls.ACCESSOR_SETTINGS)
         cls.accessor.syncdb()
         cls.accessor.connect()


### PR DESCRIPTION
graphite-web may still have a metric in its cache that have been deleted
in Cassandra. It will re-create the metric partially (every field to null
except name and read_on) when field 'read_on' is getting updated because
UPDATE and INSERT clauses in Cassandra behave like an UPSERT operation.
Adding 'IF EXISTS' makes sure that Cassandra won't create the metric if it
doesn't exists.