### PR TITLE
Make it possible to disable READ_ON updates

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -25,6 +25,8 @@ This is the main backend for BigGraphite and the one that should be used in prod
 - ```BG_CASSANDRA_DATA_READ_CONSISTENCY```: data read consistency (default: ```ONE```)
 - ```BG_CASSANDRA_META_WRITE_CONSISTENCY```: Data write consistency (default: ```ONE```)
 - ```BG_CASSANDRA_REPLICA_ID```: Identifier of this replica (default: ```0```)
+- ```BG_CASSANDRA_READ_ON_SAMPLING_RATE```: Sampling rate to update metadata field ```read_on```. Setting to ```0``` disables updating ````read-on```` (default: ```0.1```)
+
 
 You can also fine-tune the schema of your tables directly as needed. If you
 want to active read repairs, you'll also want to set:

--- a/biggraphite/drivers/cassandra.py
+++ b/biggraphite/drivers/cassandra.py
@@ -1663,8 +1663,10 @@ class _CassandraAccessor(bg_accessor.Accessor):
         return res
 
     def _update_metric_read_on(self, metric_name):
-        rate = int(1 / self.__read_on_sampling_rate)
+        if self.__read_on_sampling_rate == 0:
+            return
 
+        rate = int(1 / self.__read_on_sampling_rate)
         skip = self.__read_on_counter % rate > 0
         self.__read_on_counter += 1
 


### PR DESCRIPTION
Setting BG_CASSANDRA_READ_ON_SAMPLING_RATE to 0 skips updating the read_on 