### PR TITLE
Without this import there is a failure to use function.

### DIFF
--- a/biggraphite/settings.py
+++ b/biggraphite/settings.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Module to handle settings."""
 import distutils
+import distutils.util
 
 from biggraphite import accessor_factory as bg_accessor_factory
 from biggraphite import cache_factory as bg_cache_factory


### PR DESCRIPTION
The strtobool() call fails saying that the module util does
not exist.