### PR TITLE
changed comparison for aggregator to match unicode

### DIFF
--- a/biggraphite/metric.py
+++ b/biggraphite/metric.py
@@ -310,7 +310,7 @@ class Aggregator(enum.Enum):
             return None
 
         for agg in cls:
-            if agg.value is name:
+            if agg.value == name:
                 return agg
 
         raise InvalidArgumentError("Unknown carbon aggregation: %s" % name)

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -167,6 +167,14 @@ class TestMetricMetadata(unittest.TestCase):
             ),
             (
                 {
+                    "aggregator": u"sum",
+                    "retention": "86400*1s:10080*60s",
+                    "carbon_xfilesfactor": 0.5,
+                },
+                bg_metric.Aggregator.total,
+            ),
+            (
+                {
                     "aggregator": "total",
                     "retention": "86400*1s:10080*60s",
                     "carbon_xfilesfactor": 0.5,


### PR DESCRIPTION
changed from 'is' to '==' for aggregation name comparison as it would
not match unicode in python2.7