### PR TITLE
Fix daemon launch by unregistering Twisted reactor

### DIFF
--- a/biggraphite/cli/bg_carbon_aggregator_cache.py
+++ b/biggraphite/cli/bg_carbon_aggregator_cache.py
@@ -35,6 +35,9 @@ def main(_executable=sys.argv[0], _sys_path=sys.path):
     # Importing the plugin registers it.
     from biggraphite.plugins import carbon as unused_carbon  # noqa
 
+    if 'twisted.internet.reactor' in sys.modules:
+        del sys.modules['twisted.internet.reactor']
+
     try:
         # The carbon code tries to guess GRAPHITE_ROOT from the filename
         # given to run_twistd_plugin() to set GRAPHITE_ROOT. This is then

--- a/biggraphite/cli/bg_carbon_cache.py
+++ b/biggraphite/cli/bg_carbon_cache.py
@@ -35,6 +35,9 @@ def main(_executable=sys.argv[0], _sys_path=sys.path):
     # Importing the plugin registers it.
     from biggraphite.plugins import carbon as unused_carbon  # noqa
 
+    if 'twisted.internet.reactor' in sys.modules:
+        del sys.modules['twisted.internet.reactor']
+
     try:
         # The carbon code tries to guess GRAPHITE_ROOT from the filename
         # given to run_twistd_plugin() to set GRAPHITE_ROOT. This is then

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ packages = setuptools.find_packages()
 
 setuptools.setup(
     name="biggraphite",
-    version="0.14.19",
+    version="0.14.20",
     maintainer="Criteo Graphite Team",
     maintainer_email="github@criteo.com",
     description="Simple Scalable Time Series Database.",


### PR DESCRIPTION
The recent cassandra_driver update triggered a reactor installation before starting to parse biggraphite configuration. This is triggering a failure because biggraphite can't initialize its own reactor, making the bg daemon fails.

Also, bumping to 0.14.20.