### PR TITLE
Upgrade travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: python
 ### Trusty uses java8 default jdk11 in xenial seems to interfere with cassandra booting
-dist: trusty
+dist: xenial
 matrix:
   include:
     - python: '2.7'
       env: TOXENV=py27-coverage
     - python: '3.6'
       env: TOXENV=py36-coverage
+    - python: 'pypy'
+      env: TOXENV=pypy-coverage
+    - python: 'pypy'
+      env: TOXENV=pylama
     - language: java
       jdk: openjdk8
       env: JAVA=true
@@ -39,4 +43,7 @@ after_success:
 sudo: required
 
 before_install:
+   - wget https://raw.githubusercontent.com/michaelklishin/jdk_switcher/7e512921ba5a6e93ce304683f099e3c0525330b1/jdk_switcher.sh
+   - source ./jdk_switcher.sh
+   - jdk_switcher use openjdk8
    - ./tools/install-deps.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ after_success:
 sudo: required
 
 before_install:
+# We need to install jdk8 for cassandra.
    - wget https://raw.githubusercontent.com/michaelklishin/jdk_switcher/7e512921ba5a6e93ce304683f099e3c0525330b1/jdk_switcher.sh
    - source ./jdk_switcher.sh
    - jdk_switcher use openjdk8

--- a/biggraphite/cli/command.py
+++ b/biggraphite/cli/command.py
@@ -104,10 +104,17 @@ def add_sharding_arguments(parser):
     parser.add_argument("--shard", help="Shard number.", type=int, default=0)
     parser.add_argument("--nshards", help="Number of shards.", type=int, default=1)
 
+
 def add_clean_arguments(parser):
     """Add cleaning arguments to a parser.
 
     clear() will use this arguments
     """
-    parser.add_argument("--disable-clean-directories", help="Disable cleaning directories", action="store_true", default=False)
-    parser.add_argument("--disable-clean-metrics", help="Disable cleaning outdated metrics", action="store_true", default=False)
+    parser.add_argument("--disable-clean-directories",
+                        help="Disable cleaning directories",
+                        action="store_true",
+                        default=False)
+    parser.add_argument("--disable-clean-metrics",
+                        help="Disable cleaning outdated metrics",
+                        action="store_true",
+                        default=False)

--- a/biggraphite/cli/import_whisper.py
+++ b/biggraphite/cli/import_whisper.py
@@ -62,7 +62,7 @@ def metric_name_from_wsp(root_dir, prefix, wsp_path):
       The metric name.
     """
     relpath = os.path.relpath(wsp_path, root_dir)
-    assert ".." not in relpath, "%s not a child of %" % (root_dir, wsp_path)
+    assert ".." not in relpath, "%s not a child of %s" % (root_dir, wsp_path)
     relpath_noext = os.path.splitext(relpath)[0]
     return prefix + relpath_noext.replace(os.path.sep, ".")
 

--- a/biggraphite/cli/web/namespaces/bgutil.py
+++ b/biggraphite/cli/web/namespaces/bgutil.py
@@ -168,7 +168,7 @@ class BgUtilAsyncResource(rp.Resource):
                     skip = True
                     break
 
-            if skip == False:
+            if not skip:
                 label = self._make_label(command_name)
                 context.task_runner.submit(label, cmd, opts)
         except UnknownCommandException as e:

--- a/biggraphite/cli/web/worker.py
+++ b/biggraphite/cli/web/worker.py
@@ -109,7 +109,13 @@ class BgUtilTask:
         self.status = BgUtilTaskStatus.TIMED_OUT
 
     def is_finished(self):
-        return self.status not in [BgUtilTaskStatus.CREATED, BgUtilTaskStatus.SUBMITTED, BgUtilTaskStatus.STARTED]
+        """Is the task finished."""
+        return self.status not in [
+            BgUtilTaskStatus.CREATED,
+            BgUtilTaskStatus.SUBMITTED,
+            BgUtilTaskStatus.STARTED
+        ]
+
 
 class BgUtilTaskStatus(enum.Enum):
     """Status of a BgUtilTask."""

--- a/biggraphite/metadata_cache.py
+++ b/biggraphite/metadata_cache.py
@@ -247,6 +247,7 @@ class MemoryCache(MetadataCache):
         self.__size = settings.get("size", 1 * 1000 * 1000)
         self.__ttl = int(settings.get("ttl", 24 * 60 * 60))
         self._max_size.set(self.__size)
+        self.__cache = None
 
     def open(self):
         """Allocate ressources used by the cache."""

--- a/biggraphite/metric.py
+++ b/biggraphite/metric.py
@@ -582,12 +582,12 @@ class Retention(object):
         return self.stages[1:]
 
     @classmethod
-    def from_carbon(cls, l):
+    def from_carbon(cls, elem):
         """Make new instance from list of (precision, points).
 
         Note that precision is first, unlike in Stage.__init__
         """
-        stages = [Stage(points=points, precision=precision) for precision, points in l]
+        stages = [Stage(points=points, precision=precision) for precision, points in elem]
         return cls(stages)
 
     def find_stage_for_ts(self, searched, now):


### PR DESCRIPTION
Moving travis build to xenial instead of trusty, as this last one won't make our pypy tests working. This includes some linting fixes & minor test fixes.