### PR TITLE
Dump all metrics names on disk when cleaning.

### DIFF
--- a/.github/workflows/biggraphite.yml
+++ b/.github/workflows/biggraphite.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [ '2.x', '3.x', 'pypy-2.7', 'pypy-3.6' ]
+        python-version: [ '3.x', 'pypy-3.6' ]
 
     env:
       JAVA: false # Default


### PR DESCRIPTION
When cleaning metrics, we're sequentialy listing all metrics in the
unfiltered way to do so. Therefore, adding a way to extract all those
for debug/catalog reasons.
This is not enabled by default, and is triggered only when method
is 'unfiltered' and the env. var CLEAN_DUMP_METRICS is set.

While I'm at it, disabling python 2 builds & checks.